### PR TITLE
Deduplicate on strain, instead of isolate_ID, because strain is what …

### DIFF
--- a/data/clean_metadata.tsv
+++ b/data/clean_metadata.tsv
@@ -1519,7 +1519,6 @@ EPI2187569|2022-wk39-06_HA_H5	A/brant goose/Netherlands/22015163-002/2022	avian_
 EPI2137774|2022-wk33-20_HA_H5	A/common shelduck/Netherlands/22012866-001/2022	avian_flu	EPI_ISL_14751461	2022-07-25	Europe	Netherlands	Provincie Zeeland	NA	Tadorna tadorna	NA
 EPI2744786|A/black-headed gull/Sweden/SVA230621SZ0030/FB002052/H-2023	A/black-headed gull/Sweden/SVA230621SZ0030/FB002052/H-2023	avian_flu	EPI_ISL_18257965	2023-06-20	Europe	Sweden	Kalmar Lan	Kalmar Kommun	Chroicocephalus ridibundus	Wild
 EPI2744778|A/black-headed gull/Sweden/SVA230621SZ0030/FB002054/H-2023	A/black-headed gull/Sweden/SVA230621SZ0030/FB002054/H-2023	avian_flu	EPI_ISL_18257964	2023-06-20	Europe	Sweden	Kalmar Lan	Kalmar Kommun	Chroicocephalus ridibundus	Wild
-EPI2744770|A/black-headed gull/Sweden/SVA230621SZ0030/FB002054/H-2023	A/black-headed gull/Sweden/SVA230621SZ0030/FB002054/H-2023	avian_flu	EPI_ISL_18257963	2023-06-20	Europe	Sweden	Kalmar Lan	Kalmar Kommun	Chroicocephalus ridibundus	Wild
 EPI2744762|A/black-headed gull/Sweden/SVA230621SZ0030/FB002055/H-2023	A/black-headed gull/Sweden/SVA230621SZ0030/FB002055/H-2023	avian_flu	EPI_ISL_18257885	2023-06-16	Europe	Sweden	Kalmar Lan	Kalmar Kommun	Chroicocephalus ridibundus	Wild
 EPI2744754|A/black-headed gull/Sweden/SVA230621SZ0030/FB002056/H-2023	A/black-headed gull/Sweden/SVA230621SZ0030/FB002056/H-2023	avian_flu	EPI_ISL_18257883	2023-06-16	Europe	Sweden	Kalmar Lan	Kalmar Kommun	Chroicocephalus ridibundus	Wild
 EPI2744746|A/black-headed gull/Sweden/SVA230622SZ0219/FB002087/C-2023	A/black-headed gull/Sweden/SVA230622SZ0219/FB002087/C-2023	avian_flu	EPI_ISL_18257880	2023-06-22	Europe	Sweden	Uppsala Lan	Knivsta Kommun	Chroicocephalus ridibundus	Wild
@@ -1539,16 +1538,13 @@ EPI2957032|A/barnacle goose/Sweden/SVA240110SZ0256/FB000047/M-2024	A/barnacle go
 EPI2957024|A/barnacle goose/Sweden/SVA240110SZ0254/FB000068/M-2024	A/barnacle goose/Sweden/SVA240110SZ0254/FB000068/M-2024	avian_flu	EPI_ISL_18815329	2024-01-11	Europe	Sweden	Skane Lan	Svedala Kommun	Branta leucopsis	Wild
 EPI3236201|A/chicken/Hiroshima/TU10-17/2024	A/chicken/Hiroshima/TU10-17/2024	avian_flu	EPI_ISL_19074698	2024-03-12	Asia	Japan	Hiroshima	NA	Gallus gallus domesticus	Domestic
 EPI2306997|221221_106_H5N1_72P_Seg4_HA	A/chicken/Sakhalin/37-20V/2022	avian_flu	EPI_ISL_16619028	2022-11-04	Europe	Russian Federation	Sakhalin Oblast	NA	Gallus gallus domesticus	NA
-EPI2306989|221221_106_H5N1_71P_Seg4_HA	A/chicken/Sakhalin/37-20V/2022	avian_flu	EPI_ISL_16619027	2022-11-04	Europe	Russian Federation	Sakhalin Oblast	NA	Gallus gallus domesticus	NA
 EPI2306981|221221_106_H5N1_70P_Seg4_HA	A/chicken/Sakhalin/37-12V/2022	avian_flu	EPI_ISL_16619026	2022-11-04	Europe	Russian Federation	Sakhalin Oblast	NA	Gallus gallus domesticus	NA
 EPI2306973|221221_106_H5N1_69P_Seg4_HA	A/chicken/Sakhalin/37-9V/2022	avian_flu	EPI_ISL_16619025	2022-11-04	Europe	Russian Federation	Sakhalin Oblast	NA	Gallus gallus domesticus	NA
 EPI2306965|221221_106_H5N1_68P_Seg4_HA	A/chicken/Sakhalin/37-7V/2022	avian_flu	EPI_ISL_16619011	2022-11-04	Europe	Russian Federation	Sakhalin Oblast	NA	Gallus gallus domesticus	NA
 EPI2306957|221221_106_H5N1_67P_Seg4_HA	A/chicken/Sakhalin/37-4V/2022	avian_flu	EPI_ISL_16618996	2022-11-04	Europe	Russian Federation	Sakhalin Oblast	NA	Gallus gallus domesticus	NA
-EPI2306949|221221_106_H5N1_66P_Seg4_HA	A/chicken/Sakhalin/37-4V/2022	avian_flu	EPI_ISL_16618988	2022-11-04	Europe	Russian Federation	Sakhalin Oblast	NA	Gallus gallus domesticus	NA
 EPI2306941|221221_106_H5N1_65P_Seg4_HA	A/chicken/Sakhalin/37-3V/2022	avian_flu	EPI_ISL_16618987	2022-11-04	Europe	Russian Federation	Sakhalin Oblast	NA	Gallus gallus domesticus	NA
 EPI2306933|221221_106_H5N1_64P_Seg4_HA	A/chicken/Sakhalin/37-2V/2022	avian_flu	EPI_ISL_16618986	2022-11-04	Europe	Russian Federation	Sakhalin Oblast	NA	Gallus gallus domesticus	NA
 EPI2306925|221221_106_H5N1_63P_Seg4_HA	A/chicken/Sakhalin/37-1V/2022	avian_flu	EPI_ISL_16618985	2022-11-04	Europe	Russian Federation	Sakhalin Oblast	NA	Gallus gallus domesticus	NA
-EPI2306917|221221_106_H5N1_62P_Seg4_HA	A/chicken/Sakhalin/37-1V/2022	avian_flu	EPI_ISL_16618984	2022-11-04	Europe	Russian Federation	Sakhalin Oblast	NA	Gallus gallus domesticus	NA
 EPI2306909|221221_106_H5N1_58P_Seg4_HA	A/chicken/Khabarovsk/24-12V/2022	avian_flu	EPI_ISL_16618982	2022-08-25	Europe	Russian Federation	Khabarovsk Krai	NA	Gallus gallus domesticus	NA
 EPI2306901|221221_106_H5N1_57P_Seg4_HA	A/chicken/Khabarovsk/24-10V/2022	avian_flu	EPI_ISL_16618981	2022-08-25	Europe	Russian Federation	Khabarovsk Krai	NA	Gallus gallus domesticus	NA
 EPI2306893|221221_106_H5N1_56P_Seg4_HA	A/chicken/Khabarovsk/24-9V/2022	avian_flu	EPI_ISL_16618980	2022-08-25	Europe	Russian Federation	Khabarovsk Krai	NA	Gallus gallus domesticus	NA
@@ -1560,9 +1556,7 @@ EPI2306845|221221_106_H5N1_50P_Seg4_HA	A/chicken/Khabarovsk/24-3V/2022	avian_flu
 EPI2306837|221221_106_H5N1_49P_Seg4_HA	A/chicken/Khabarovsk/24-2V/2022	avian_flu	EPI_ISL_16618973	2022-08-25	Europe	Russian Federation	Khabarovsk Krai	NA	Gallus gallus domesticus	NA
 EPI2306829|221221_106_H5N1_48P_Seg4_HA	A/chicken/Khabarovsk/24-1V/2022	avian_flu	EPI_ISL_16618972	2022-08-25	Europe	Russian Federation	Khabarovsk Krai	NA	Gallus gallus domesticus	NA
 EPI2306797|221221_106_H5N1_44P_Seg4_HA	A/chicken/Magadan/14-7V/2022	avian_flu	EPI_ISL_16618968	2022-10-12	Europe	Russian Federation	Magadan Oblast	NA	Gallus gallus domesticus	NA
-EPI2306789|221221_106_H5N1_43P_Seg4_HA	A/chicken/Magadan/14-7V/2022	avian_flu	EPI_ISL_16618967	2022-10-12	Europe	Russian Federation	Magadan Oblast	NA	Gallus gallus domesticus	NA
 EPI2306781|221221_106_H5N1_42P_Seg4_HA	A/chicken/Magadan/14-6V/2022	avian_flu	EPI_ISL_16618966	2022-10-12	Europe	Russian Federation	Magadan Oblast	NA	Gallus gallus domesticus	NA
-EPI2306773|221221_106_H5N1_41P_Seg4_HA	A/chicken/Magadan/14-6V/2022	avian_flu	EPI_ISL_16618965	2022-10-12	Europe	Russian Federation	Magadan Oblast	NA	Gallus gallus domesticus	NA
 EPI2306733|221221_106_H5N1_36P_Seg4_HA	A/chicken/Magadan/14-1V/2022	avian_flu	EPI_ISL_16618960	2022-10-12	Europe	Russian Federation	Magadan Oblast	NA	Gallus gallus domesticus	NA
 EPI2306725|221221_106_H5N1_34P_Seg4_HA	A/chicken/Rostov/6-3V/2022	avian_flu	EPI_ISL_16618959	2022-08-17	Europe	Russian Federation	Rostov Oblast	NA	Gallus gallus domesticus	NA
 EPI2306717|221221_106_H5N1_33P_Seg4_HA	A/chicken/Rostov/6-2V/2022	avian_flu	EPI_ISL_16618958	2022-08-17	Europe	Russian Federation	Rostov Oblast	NA	Gallus gallus domesticus	NA
@@ -1571,16 +1565,11 @@ EPI2306701|221221_106_H5N1_31P_Seg4_HA	A/chicken/Saratov/245-14V/2022	avian_flu	
 EPI2306693|221221_106_H5N1_30P_Seg4_HA	A/chicken/Saratov/245-13V/2022	avian_flu	EPI_ISL_16618955	2022-09-15	Europe	Russian Federation	Saratov Oblast	NA	Gallus gallus domesticus	NA
 EPI2306685|221221_106_H5N1_29P_Seg4_HA	A/chicken/Saratov/245-11V/2022	avian_flu	EPI_ISL_16618954	2022-09-15	Europe	Russian Federation	Saratov Oblast	NA	Gallus gallus domesticus	NA
 EPI2306677|221221_106_H5N1_28P_Seg4_HA	A/chicken/Saratov/245-9V/2022	avian_flu	EPI_ISL_16618953	2022-09-15	Europe	Russian Federation	Saratov Oblast	NA	Gallus gallus domesticus	NA
-EPI2306669|221221_106_H5N1_27P_Seg4_HA	A/chicken/Saratov/245-9V/2022	avian_flu	EPI_ISL_16618951	2022-09-15	Europe	Russian Federation	Saratov Oblast	NA	Gallus gallus domesticus	NA
 EPI2306661|221221_106_H5N1_26P_Seg4_HA	A/chicken/Saratov/245-7V/2022	avian_flu	EPI_ISL_16618950	2022-09-15	Europe	Russian Federation	Saratov Oblast	NA	Gallus gallus domesticus	NA
-EPI2306653|221221_106_H5N1_25P_Seg4_HA	A/chicken/Saratov/245-7V/2022	avian_flu	EPI_ISL_16618935	2022-09-15	Europe	Russian Federation	Saratov Oblast	NA	Gallus gallus domesticus	NA
 EPI2306645|221221_106_H5N1_24P_Seg4_HA	A/chicken/Saratov/245-5V/2022	avian_flu	EPI_ISL_16618932	2022-09-15	Europe	Russian Federation	Saratov Oblast	NA	Gallus gallus domesticus	NA
-EPI2306637|221221_106_H5N1_23P_Seg4_HA	A/chicken/Saratov/245-5V/2022	avian_flu	EPI_ISL_16618931	2022-09-15	Europe	Russian Federation	Saratov Oblast	NA	Gallus gallus domesticus	NA
 EPI2306629|221221_106_H5N1_22P_Seg4_HA	A/chicken/Saratov/245-4V/2022	avian_flu	EPI_ISL_16618930	2022-09-15	Europe	Russian Federation	Saratov Oblast	NA	Gallus gallus domesticus	NA
 EPI2306621|221221_106_H5N1_21P_Seg4_HA	A/chicken/Saratov/245-2V/2022	avian_flu	EPI_ISL_16618929	2022-09-15	Europe	Russian Federation	Saratov Oblast	NA	Gallus gallus domesticus	NA
-EPI2306613|221221_106_H5N1_20P_Seg4_HA	A/chicken/Saratov/245-2V/2022	avian_flu	EPI_ISL_16618928	2022-09-15	Europe	Russian Federation	Saratov Oblast	NA	Gallus gallus domesticus	NA
 EPI2306605|221221_106_H5N1_19P_Seg4_HA	A/chicken/Saratov/245-1V/2022	avian_flu	EPI_ISL_16618927	2022-09-15	Europe	Russian Federation	Saratov Oblast	NA	Gallus gallus domesticus	NA
-EPI2306597|221221_106_H5N1_18P_Seg4_HA	A/chicken/Saratov/245-1V/2022	avian_flu	EPI_ISL_16618926	2022-09-15	Europe	Russian Federation	Saratov Oblast	NA	Gallus gallus domesticus	NA
 EPI2306589|221221_106_H5N1_17P_Seg4_HA	A/chicken/Chelyabinsk/241-5V/2022	avian_flu	EPI_ISL_16618925	2022-07-28	Europe	Russian Federation	Chelyabinsk Oblast	NA	Gallus gallus domesticus	NA
 EPI2306581|221221_106_H5N1_16P_Seg4_HA	A/chicken/Chelyabinsk/241-4V/2022	avian_flu	EPI_ISL_16618924	2022-07-28	Europe	Russian Federation	Chelyabinsk Oblast	NA	Gallus gallus domesticus	NA
 EPI2306573|221221_106_H5N1_15P_Seg4_HA	A/chicken/Chelyabinsk/241-1V/2022	avian_flu	EPI_ISL_16618923	2022-07-28	Europe	Russian Federation	Chelyabinsk Oblast	NA	Gallus gallus domesticus	NA
@@ -1590,13 +1579,11 @@ EPI2208919|A/Gallus_gallus/Belgium/11387_0002/2022	A/Gallus_gallus/Belgium/11387
 EPI1987373|A/pigeon/Germany-NW/AI00951/2022	A/pigeon/Germany-NW/AI00951/2022	avian_flu	EPI_ISL_10261376	2022-01-24	Europe	Germany	North Rhine-Westphalia	Regierungsbezirk Arnsberg	Pigeon	Wild
 EPI2699043|A_black-headed-gull_Finland_8096_2023_HA	A/black-headed-gull/Finland/8096/2023	avian_flu	EPI_ISL_18127193	2023-07-18	Europe	Finland	NA	NA	Black-headed gull	NA
 EPI2306821|221221_106_H5N1_47P_Seg4_HA	A/domestic goose/Magadan/14-9V/2022	avian_flu	EPI_ISL_16618971	2022-10-12	Europe	Russian Federation	Magadan Oblast	NA	Anser anser domesticus	NA
-EPI2306813|221221_106_H5N1_46P_Seg4_HA	A/domestic goose/Magadan/14-9V/2022	avian_flu	EPI_ISL_16618970	2022-10-12	Europe	Russian Federation	Magadan Oblast	NA	Anser anser domesticus	NA
 EPI2306805|221221_106_H5N1_45P_Seg4_HA	A/domestic goose/Magadan/14-8V/2022	avian_flu	EPI_ISL_16618969	2022-10-12	Europe	Russian Federation	Magadan Oblast	NA	Anser anser domesticus	NA
 EPI2306741|221221_106_H5N1_37P_Seg4_HA	A/domestic goose/Magadan/14-3V/2022	avian_flu	EPI_ISL_16618961	2022-10-12	Europe	Russian Federation	Magadan Oblast	NA	Anser anser domesticus	NA
 EPI2122852|A/Anser_anser_domesticus/Belgium/1668_0016/2022	A/Anser_anser_domesticus/Belgium/1668_0016/2022	avian_flu	EPI_ISL_14389524	2022-01-26	Europe	Belgium	Provincie Vlaams-Brabant	Oud-Heverlee	Anser anser domesticus	Wild
 EPI3236352|A/murine/Hiroshima/TU10-B/2024	A/murine/Hiroshima/TU10-B/2024	avian_flu	EPI_ISL_19074717	2024-03-12	Asia	Japan	Hiroshima	NA	Mouse	Wild
 EPI2306765|221221_106_H5N1_40P_Seg4_HA	A/domestic duck/Magadan/14-5V/2022	avian_flu	EPI_ISL_16618964	2022-10-12	Europe	Russian Federation	Magadan Oblast	NA	Anas platyrhynchos f. domestica	NA
-EPI2306757|221221_106_H5N1_39P_Seg4_HA	A/domestic duck/Magadan/14-5V/2022	avian_flu	EPI_ISL_16618963	2022-10-12	Europe	Russian Federation	Magadan Oblast	NA	Anas platyrhynchos f. domestica	NA
 EPI2306749|221221_106_H5N1_38P_Seg4_HA	A/domestic duck/Magadan/14-4V/2022	avian_flu	EPI_ISL_16618962	2022-10-12	Europe	Russian Federation	Magadan Oblast	NA	Anas platyrhynchos f. domestica	NA
 EPI2122833|A/Tachybaptus_ruficollis/Belgium/1234_0008/2022	A/Tachybaptus_ruficollis/Belgium/1234_0008/2022	avian_flu	EPI_ISL_14389148	2022-01-24	Europe	Belgium	Provincie Vlaams-Brabant	Oud-Heverlee	Tachybaptus ruficollis	Wild
 EPI2907093|A/Falco_peregrinus/Belgium/12002_0004/2023	A/Falco_peregrinus/Belgium/12002_0004/2023	avian_flu	EPI_ISL_18750748	2023-12-10	Europe	Belgium	Provincie West-Vlaanderen	Middelkerke	Falco peregrinus	Wild
@@ -2958,7 +2945,6 @@ EPI2885885|A/chicken/Aomori/21B7C/2021(ha), EPI2885887|A/chicken/Aomori/21B7C/20
 EPI2885873|A/chicken/Aomori/21B5T/2021(ha)	A/chicken/Aomori/21B5T/2021	avian_flu	EPI_ISL_18720809	2022-04-07	Asia	Japan	Aomori	NA	Chicken	NA
 EPI2885857|A/chicken/Aomori/21B3T/2021(ha)	A/chicken/Aomori/21B3T/2021	avian_flu	EPI_ISL_18720807	2022-04-07	Asia	Japan	Aomori	NA	Chicken	NA
 EPI2885841|A/chicken/Aomori/21B1C/2021(ha)	A/chicken/Aomori/21B1C/2021	avian_flu	EPI_ISL_18720805	2022-04-07	Asia	Japan	Aomori	NA	Chicken	NA
-EPI2885686|A/chicken/Iwate/21A7T/2022(ha), EPI2885687|A/chicken/Iwate/21A7T/2022(ha)	A/chicken/Iwate/21A7T/2022	avian_flu	EPI_ISL_18720793	2022-02-11	Asia	Japan	Iwate	NA	Chicken	NA
 EPI2885671|A/chicken/Iwate/21A2T/2022(ha), EPI2885672|A/chicken/Iwate/21A2T/2022(ha)	A/chicken/Iwate/21A2T/2022	avian_flu	EPI_ISL_18720792	2022-02-11	Asia	Japan	Iwate	NA	Chicken	NA
 EPI2885655|A/chicken/Iwate/21A1T/2022(ha), EPI2885656|A/chicken/Iwate/21A1T/2022(ha)	A/chicken/Iwate/21A1T/2022	avian_flu	EPI_ISL_18720791	2022-02-11	Asia	Japan	Iwate	NA	Chicken	NA
 EPI2885640|A/chicken/Iwate/21A13T/2022(ha), EPI2885642|A/chicken/Iwate/21A13T/2022(ha)	A/chicken/Iwate/21A13T/2022	avian_flu	EPI_ISL_18720790	2022-02-11	Asia	Japan	Iwate	NA	Chicken	NA
@@ -5625,7 +5611,6 @@ EPI3093175|A/cygnus-cygnus/Romania/16986_24VIR1002-2/2023_HA	A/cygnus-cygnus/Rom
 EPI3093215|A/cygnus-olor/Romania/17003_24VIR1002-10/2023_HA	A/cygnus-olor/Romania/17003_24VIR1002-10/2023	avian_flu	EPI_ISL_18956177	2023-12-27	Europe	Romania	NA	NA	Cygnus olor	NA
 EPI3093191|A/cygnus-olor/Romania/17019_24VIR1002-4/2023_HA	A/cygnus-olor/Romania/17019_24VIR1002-4/2023	avian_flu	EPI_ISL_18956174	2023-12-28	Europe	Romania	NA	NA	Cygnus olor	NA
 EPI3093167|A/cygnus-olor/Romania/16868_24VIR1002-1/2023_HA	A/cygnus-olor/Romania/16868_24VIR1002-1/2023	avian_flu	EPI_ISL_18956171	2023-12-15	Europe	Romania	NA	NA	Cygnus olor	NA
-EPI2021095|A/mute swan/Czech Republic/785/2022	A/mute swan/Czech Republic/785/2022	avian_flu	EPI_ISL_12139999	2022-01-10	Europe	Czech Republic	Stredocesky Kraj	Davle, bank of the Vltava river; GPS: 49.8909144N, 14.4011586E	Cygnus olor	Wild
 EPI3093263|A/turkey/Croatia/76_24VIR670-1/2023_HA	A/turkey/Croatia/76_24VIR670-1/2023	avian_flu	EPI_ISL_18956183	2023-11-14	Europe	Croatia	NA	NA	Turkey	NA
 EPI3093151|A/turkey/Italy/24VIR1352-4/2024_HA	A/turkey/Italy/24VIR1352-4/2024	avian_flu	EPI_ISL_18956169	2024-02-20	Europe	Italy	NA	NA	Turkey	NA
 EPI2412842|A/Turkey/Scotland/012551/2023|HA	A/Turkey/Scotland/012551/2023	avian_flu	EPI_ISL_16956029	2023-01-21	Europe	United Kingdom	Scotland	NA	Turkey	NA
@@ -6396,7 +6381,6 @@ EPI1980980|2022-wk05-24_HA_H5	A/brant goose/Netherlands/22000648-002/2022	avian_
 EPI1980964|2022-wk05-22_HA_H5	A/barnacle goose/Netherlands/22000640-002/2022	avian_flu	EPI_ISL_9616237	2022-01-10	Europe	Netherlands	Provincie Gelderland	NA	Branta leucopsis	NA
 EPI1980908|2022-wk05-14_HA_H5	A/barnacle goose/Netherlands/22000765-004/2022	avian_flu	EPI_ISL_9616204	2022-01-12	Europe	Netherlands	Provincie Utrecht	NA	Branta leucopsis	NA
 EPI2092553|H5N1_Seg4_HA_flu-2_S96	A/chicken/Ryazan/224-1V/2022	avian_flu	EPI_ISL_13876273	2022-05-28	Europe	Russian Federation	Ryazan Oblast	NA	Gallus gallus domesticus	NA
-EPI2092545|H5N1_Seg4_HA_flu-1_S95	A/chicken/Ryazan/224-1V/2022	avian_flu	EPI_ISL_13876272	2022-05-28	Europe	Russian Federation	Ryazan Oblast	NA	Gallus gallus domesticus	NA
 EPI2799824|A/Eurasian_teal/Denmark/08501-7/2023-11-07	A/Eurasian_teal/Denmark/08501-7/2023-11-07	avian_flu	EPI_ISL_18530058	2023-11-07	Europe	Denmark	Region Syddanmark	NA	Common teal	Wild
 EPI2960209|A/turkey/France/24P000985/2024	A/turkey/France/24P000985/2024	avian_flu	EPI_ISL_18824185	2024-01-10	Europe	France	NA	NA	Meleagris gallopavo	Domestic
 EPI2526593|Node_wien_falke_23032458_segment_4	A/falcon/Austria/23032458/2023	avian_flu	EPI_ISL_17514177	2023-03-10	Europe	Austria	Bundesland Wien	Vienna	Falcon	NA
@@ -8926,7 +8910,6 @@ EPI2608564|A/Red fox/Germany/51023-60/2023	A/Red fox/Germany/51023-60/2023	avian
 NA	A/feline/South Korea/SNU-003/2023	avian_flu	EPI_ISL_18698906	NA	Asia	Korea, Republic of	NA	NA	Feline	NA
 NA	A/feline/South Korea/SNU-004/2023	avian_flu	EPI_ISL_18698905	NA	Asia	Korea, Republic of	NA	NA	Feline	NA
 EPI3360145|A/red_fox/Denmark/02424-1.02/2024	A/red_fox/Denmark/02424-1.02/2024	avian_flu	EPI_ISL_19190644	2024-01-27	Europe	Denmark	Region Midtjylland	Hedensted Kommune	Other mammals	Wild
-EPI3323142|A/black bear/Alasca/22-036396-001/2022_HA	A/black bear/Alaska/22-036396-001/2022	avian_flu	EPI_ISL_19158180	2022-10-21	North America	United States	Alaska	NA	Other mammals	NA
 EPI3323058|A/brown bear/Alasca/22-039119-001/2022_HA	A/brown bear/Alaska/22-039119-001/2022	avian_flu	EPI_ISL_19158173	2022-11-29	North America	United States	Alaska	NA	Other mammals	NA
 EPI2895023|HA A/harbor seal/Washington/23-027069-002-original/2023(H5N1)	A/harbor seal/Washington/23-027069-002/2023	avian_flu	EPI_ISL_18731638	2023-08-13	North America	United States	Washington	Jefferson County	Other mammals	NA
 EPI2894999|HA A/harbor seal/Washington/23-025991-001-original/2023(H5N1)	A/harbor seal/Washington/23-025991-001/2023	avian_flu	EPI_ISL_18731622	2023-08-25	North America	United States	Washington	Jefferson County	Other mammals	NA
@@ -9191,9 +9174,6 @@ EPI3462376|A/chicken/USA/24-020282-001/2024_HA	A/chicken/USA/24-020282-001/2024	
 EPI3462368|A/chicken/USA/24-020282-002/2024_HA	A/chicken/USA/24-020282-002/2024	avian_flu	EPI_ISL_19289559	NA	North America	United States	NA	NA	Chicken	NA
 EPI3462360|A/chicken/USA/24-020282-003/2024_HA	A/chicken/USA/24-020282-003/2024	avian_flu	EPI_ISL_19289558	NA	North America	United States	NA	NA	Chicken	NA
 EPI3462344|A/chicken/USA/24-020282-004/2024_HA	A/chicken/USA/24-020282-004/2024	avian_flu	EPI_ISL_19289556	NA	North America	United States	NA	NA	Chicken	NA
-EPI3322967|A/chicken/Alasca/22-037940-001/2022_HA	A/chicken/Alaska/22-037940-001/2022	avian_flu	EPI_ISL_19158169	2022-11-23	North America	United States	Alaska	NA	Chicken	NA
-EPI3322948|A/chicken/Alasca/22-013107-001/2022_HA	A/chicken/Alaska/22-013107-001/2022	avian_flu	EPI_ISL_19158168	2022-04-28	North America	United States	Alaska	NA	Chicken	NA
-EPI3322929|A/chicken/Alasca/22-013107-002/2022_HA	A/chicken/Alaska/22-013107-002/2022	avian_flu	EPI_ISL_19158167	2022-04-28	North America	United States	Alaska	NA	Chicken	NA
 EPI3322910|A/chicken/Alasca/22-023555-001/2022_HA	A/chicken/Alaska/22-023555-001/2022	avian_flu	EPI_ISL_19158166	2022-07-25	North America	United States	Alaska	NA	Chicken	NA
 EPI3322893|A/chicken/Alasca/22-031261-002/2022_HA	A/chicken/Alaska/22-031261-002/2022	avian_flu	EPI_ISL_19158165	2022-09-28	North America	United States	Alaska	NA	Chicken	NA
 EPI3322875|A/chicken/Alasca/22-031261-003/2022_HA	A/chicken/Alaska/22-031261-003/2022	avian_flu	EPI_ISL_19158164	2022-09-28	North America	United States	Alaska	NA	Chicken	NA
@@ -10143,7 +10123,6 @@ EPI2415831|BC23[H5]	A/chicken/Czech_Republic/1600-2/2023	avian_flu	EPI_ISL_16997
 EPI2415823|BC20[H5]	A/chicken/Czech_Republic/1600-1/2023	avian_flu	EPI_ISL_16997756	2023-01-29	Europe	Czech Republic	Jihocesky Kraj	Okres Ceske Budejovice	Chicken	Domestic
 EPI2415799|BC24[H5]	A/chicken/Czech_Republic/1690_orig/2023	avian_flu	EPI_ISL_16997753	2023-01-30	Europe	Czech Republic	Plzensky Kraj	Okres Tacov	Chicken	Domestic
 EPI2415791|BC22[H5]	A/chicken/Czech_Republic/1690/2023	avian_flu	EPI_ISL_16997752	2023-01-30	Europe	Czech Republic	Plzensky Kraj	Okres Tacov	Chicken	Domestic
-EPI2415753|A/chicken/Czech_Republic/22968_orig/2022	A/chicken/Czech_Republic/22968_orig/2022	avian_flu	EPI_ISL_16997293	2022-12-09	Europe	Czech Republic	Jihocesky Kraj	Okres Jindrichuv Hradec	Chicken	Domestic
 EPI2944583|2024-wk03-07_HA_H5	A/Chicken/Netherlands/24000703-016020/2024	avian_flu	EPI_ISL_18800494	2024-01-11	Europe	Netherlands	North Brabant	NA	Gallus gallus	NA
 EPI2861332|A/Gallus_gallus/Belgium/11632_0003/2023	A/Gallus_gallus/Belgium/11632_0003/2023	avian_flu	EPI_ISL_18668242	2023-12-08	Europe	Belgium	Provincie West-Vlaanderen	Esen	Gallus gallus	Domestic
 EPI2800242|2023-wk47-03_HA_H5	A/Chicken/Netherlands/23024352-011015/2023	avian_flu	EPI_ISL_18536648	2023-11-15	Europe	Netherlands	Provincie Noord-Holland	NA	Gallus gallus	NA
@@ -10530,9 +10509,6 @@ EPI3411332|A/raccoon/Colorado/24-014781-001/2024_HA	A/raccoon/Colorado/24-014781
 EPI3411326|A/house mouse/New Mexico/24-014782-003/2024_HA	A/house mouse/New Mexico/24-014782-003/2024	avian_flu	EPI_ISL_19228462	2024-05-09	North America	United States	New Mexico	NA	Other mammals	NA
 EPI3410418|A/raccoon/USA/24-012313-002/2024	A/raccoon/USA/24-012313-002/2024	avian_flu	EPI_ISL_19227502	NA	North America	United States	NA	NA	Other mammals	NA
 EPI3408777|A/alpaca/Idaho/24-015080-001/2024_HA	A/alpaca/Idaho/24-015080-001/2024	avian_flu	EPI_ISL_19227278	2024-05-20	North America	United States	Idaho	NA	Other mammals	NA
-EPI2759139|HA_A/harbor seal/Washington/23-026504-002-original/2023	A/harbor seal/Washington/23-026504-002/2023	avian_flu	EPI_ISL_18311028	2023-08-29	North America	United States	Washington	Jefferson County	Other mammals	NA
-EPI2759131|HA_A/harbor seal/Washington/23-026504-001-original/2023	A/harbor seal/Washington/23-026504-001/2023	avian_flu	EPI_ISL_18311027	2023-08-29	North America	United States	Washington	Jefferson County	Other mammals	NA
-EPI2759115|HA_A/harbor seal/Washington/23-025991-001-original/2023	A/harbor seal/Washington/23-025991-001/2023	avian_flu	EPI_ISL_18311025	2023-08-25	North America	United States	Washington	Jefferson County	Other mammals	NA
 EPI2759107|HA_A/harbor seal/Washington/23-025744-002-original/2023	A/harbor seal/Washington/23-025744-002/2023	avian_flu	EPI_ISL_18311024	2023-08-19	North America	United States	Washington	Jefferson County	Other mammals	NA
 EPI2759099|HA_A/harbor seal/Washington/23-025744-001-original/2023	A/harbor seal/Washington/23-025744-001/2023	avian_flu	EPI_ISL_18311023	2023-08-19	North America	United States	Washington	Jefferson County	Other mammals	NA
 EPI2507003|A/striped skunk/Kansas/W23-094/2023	A/striped skunk/Kansas/W23-094/2023	avian_flu	EPI_ISL_17424646	2023-01-27	North America	United States	Kansas	NA	Other mammals	NA
@@ -10563,7 +10539,6 @@ EPI2473564|HA_A/red fox/North Dakota/22-017061-001-original/2022(H5N1)	A/red fox
 EPI2473550|HA_A/red fox/Minnesota/22-017056-001-original/2022(H5N1)	A/red fox/Minnesota/22-017056-001/2022	avian_flu	EPI_ISL_17260672	NA	North America	United States	Minnesota	Scott County	Other mammals	NA
 EPI2473536|HA_A/Virginia opossum/Iowa/22-016780-003-original/2022(H5N1)	A/Virginia opossum/Iowa/22-016780-003/2022	avian_flu	EPI_ISL_17260671	2022-05-25	North America	United States	Iowa	Buchanan County	Other mammals	NA
 EPI2473522|HA_A/fox/Utah/22-016402-001-original/2022(H5N1)	A/fox/Utah/22-016402-001/2022	avian_flu	EPI_ISL_17260670	2022-05-24	North America	United States	Utah	Salt Lake County	Other mammals	NA
-EPI2473508|HA_A/red fox/Alaska/22-016300-001-original/2022(H5N1)	A/red fox/Alaska/22-016300-001/2022	avian_flu	EPI_ISL_17260669	2022-05-10	North America	United States	Alaska	Aleutians West Census Area	Other mammals	NA
 EPI2473494|HA_A/fox/New York/22-015066-001-original/2022(H5N1)	A/fox/New York/22-015066-001/2022	avian_flu	EPI_ISL_17260668	2022-04-15	North America	United States	New York	Saint Lawrence County	Other mammals	NA
 EPI2473482|HA_A/fox/Wisconsin/22-014746-026-original/2022(H5N1)	A/fox/Wisconsin/22-014746-026/2022	avian_flu	EPI_ISL_17260667	2022-05-06	North America	United States	Wisconsin	Grant County	Other mammals	NA
 EPI2473469|HA_A/fox/Wisconsin/22-014746-021-original/2022(H5N1)	A/fox/Wisconsin/22-014746-021/2022	avian_flu	EPI_ISL_17260666	2022-05-06	North America	United States	Wisconsin	Grant County	Other mammals	NA
@@ -10736,7 +10711,6 @@ EPI2606425|A/chicken/Ohio/OH22-20542-2/2022_HA	A/chicken/Ohio/OH22-20542-2/2022	
 EPI2606338|A/chicken/Ohio/OH22-20542-1/2022_HA	A/chicken/Ohio/OH22-20542-1/2022	avian_flu	EPI_ISL_17851847	2022-09-01	North America	United States	Ohio	NA	Chicken	NA
 EPI2589259|A/laying_hen/Austria/22005859-001/2022_segment_4	A/laying_hen/Austria/22005859-001/2022	avian_flu	EPI_ISL_17785727	2022-01-19	Europe	Austria	Bundesland Oberosterreich	Rohrbach	Chicken	NA
 EPI2310696|R99-BC92[H5]	A/chicken/Czech_Republic/574/2023	avian_flu	EPI_ISL_16638696	2023-01-11	Europe	Czech Republic	Kralovehradecky Kraj	Okres Jicin	Chicken	Domestic
-EPI2310688|R99-BC88[H5]	A/chicken/Czech_Republic/22911-1/2022	avian_flu	EPI_ISL_16638676	2022-12-08	Europe	Czech Republic	Stredocesky Kraj	Okres Praha-Vychod	Chicken	Domestic
 EPI2310672|R99-BC84[H5]	A/chicken/Czech_Republic/22910-3/2022	avian_flu	EPI_ISL_16638643	2022-12-08	Europe	Czech Republic	Stredocesky Kraj	Okres Praha-Vychod	Chicken	Domestic
 EPI2310664|R99-BC81[H5]	A/chicken/Czech_Republic/22910-2/2022	avian_flu	EPI_ISL_16638642	2022-12-08	Europe	Czech Republic	Stredocesky Kraj	Okres Praha-Vychod	Chicken	Domestic
 EPI2310656|R99-BC83[H5]	A/chicken/Czech_Republic/22910-1/2022	avian_flu	EPI_ISL_16638641	2022-12-08	Europe	Czech Republic	Stredocesky Kraj	Okres Praha-Vychod	Chicken	Domestic
@@ -11199,7 +11173,6 @@ EPI2219984|A/chicken/South Africa/JB2201/2022	A/chicken/South Africa/JB2201/2022
 EPI2085870|A/chicken/East_Java/Av1955/2022	A/chicken/East_Java/Av1955/2022	avian_flu	EPI_ISL_13690275	2022-03-05	Asia	Indonesia	East Java	NA	Gallus gallus domesticus	Domestic
 EPI2944633|A/Hartlaubs gul/South Africa/718335 H088/2023	A/Hartlaubs gul/South Africa/718335 H088/2023	avian_flu	EPI_ISL_18801266	2023-05-29	Africa	South Africa	Province of the Western Cape	Edgemead	Chroicocephalus	Wild
 EPI2610690|A/cat/Poland/Gda1/2023	A/cat/Poland/Gda1/2023	avian_flu	EPI_ISL_17949824	2023-06-21	Europe	Poland	Pomeranian Voivodeship	NA	Felis catus	Domestic
-NA	A/falcon/Peru/A273/2022	avian_flu	EPI_ISL_17526123	NA	South America	Peru	NA	NA	Falcon	NA
 EPI3495209|A/ peregrine falcon /Israel/975/2023	A/ peregrine falcon /Israel/975/2023	avian_flu	EPI_ISL_19327338	2023-12-28	Asia	Israel	Northern District	NA	Falco peregrinus	Wild
 EPI2589429|A/peregrine falcon/Sweden/SVA230523SZ0426/FB001739/M-2023	A/peregrine falcon/Sweden/SVA230523SZ0426/FB001739/M-2023	avian_flu	EPI_ISL_17787128	2023-05-06	Europe	Sweden	Skane Lan	Klippans Kommun	Falco peregrinus	Wild
 EPI2311511|31291|22MM00756|HA	A/peregrine falcon/MA/22MM00756/2022	avian_flu	EPI_ISL_16641791	2022-06-16	North America	United States	Massachusetts	Essex County	Falco peregrinus	NA
@@ -11416,8 +11389,6 @@ EPI3412394|A/alpaca/Idaho/24-014328-011/2024_HA	A/alpaca/Idaho/24-014328-011/202
 EPI3411168|A/goat/USA/24-007234-059/2024	A/goat/USA/24-007234-059/2024	avian_flu	EPI_ISL_19228238	NA	North America	United States	NA	NA	Other mammals	NA
 EPI3410859|A/raccoon/USA/24-011659-001/2024	A/raccoon/USA/24-011659-001/2024	avian_flu	EPI_ISL_19228198	NA	North America	United States	NA	NA	Other mammals	NA
 EPI3410851|A/raccoon/USA/24-011659-002/2024	A/raccoon/USA/24-011659-002/2024	avian_flu	EPI_ISL_19228197	NA	North America	United States	NA	NA	Other mammals	NA
-EPI2895495|HA A/harbor seal/Washington/23-025744-002-original/2023(H5N1)	A/harbor seal/Washington/23-025744-002/2023	avian_flu	EPI_ISL_18737559	2023-08-19	North America	United States	Washington	Jefferson County	Other mammals	NA
-EPI2895487|HA A/harbor seal/Washington/23-025744-001-original/2023(H5N1)	A/harbor seal/Washington/23-025744-001/2023	avian_flu	EPI_ISL_18737558	2023-08-19	North America	United States	Washington	Jefferson County	Other mammals	NA
 EPI2609545|A/sea lion/Arica y Parinacota/240270-1/2023_HA	A/sea lion/Arica y Parinacota/240270-1/2023	avian_flu	EPI_ISL_17885976	2023-03-01	South America	Chile	Region Arica y Parinacota	NA	Other mammals	NA
 EPI2609536|A/sea lion/Tarapaca/240524-2/2023_HA	A/sea lion/Tarapaca/240524-2/2023	avian_flu	EPI_ISL_17885975	2023-03-07	South America	Chile	Region de Tarapaca	NA	Other mammals	NA
 EPI2500049|A/Red Fox/PEI/FAV-0544-P1/2022	A/Red Fox/PEI/FAV-0544-P1/2022	avian_flu	EPI_ISL_17394088	2022-05-19	North America	Canada	Prince Edward Island	NA	Other mammals	Wild
@@ -11553,7 +11524,6 @@ EPI2895311|HA A/glaucous gull/Washington/23-025001-003-original/2023(H5N1)	A/gla
 EPI2895303|HA A/glaucous gull/Washington/23-025001-002-original/2023(H5N1)	A/glaucous gull/Washington/23-025001-002/2023	avian_flu	EPI_ISL_18737455	2023-08-11	North America	United States	Washington	NA	Avian	NA
 EPI2895295|HA A/caspian tern/Washington/23-025001-001-original/2023(H5N1)	A/caspian tern/Washington/23-025001-001/2023	avian_flu	EPI_ISL_18737454	2023-08-11	North America	United States	Washington	NA	Avian	NA
 EPI2895287|HA A/manx shearwater/Alaska/23-025002-003-original/2023(H5N1)	A/manx shearwater/Alaska/23-025002-003/2023	avian_flu	EPI_ISL_18737453	2023-07-19	North America	United States	Alaska	NA	Avian	Wild
-EPI2895279|HA A/glaucous gull/Alaska/23-025003-001-original/2023(H5N1)	A/glaucous gull/Alaska/23-025003-001/2023	avian_flu	EPI_ISL_18737452	2023-07-22	North America	United States	Alaska	NA	Avian	NA
 EPI2863072|A/Eurasian teal/Netherlands/3/2023_HA_HPAI_H5N1	A/Eurasian teal/Netherlands/3/2023	avian_flu	EPI_ISL_18673081	2023-12-05	Europe	Netherlands	Eendenkooi Slijkerman	NA	Avian	NA
 EPI2794014|A/black kite/Kagoshima/KU-140/2022 (H5N1)	A/black kite/Kagoshima/KU-140/2022 (H5N1)	avian_flu	EPI_ISL_18508592	2022-11-28	Asia	Japan	Kagoshima	NA	Avian	NA
 EPI2610740|	EPI2610729	A/large-billed crow/Hokkaido/B049/2023	avian_flu	EPI_ISL_17950254	2023-04-11	Asia	Japan	Hokkaido	Sapporo	Avian	Wild
@@ -11926,7 +11896,6 @@ EPI2553188|A/Common tern/Luxembourg/23109715/2023	A/Common tern/Luxembourg/23109
 EPI2534293|A/pelican/Honduras/23-000009-001/2022	A/pelican/Honduras/23-000009-001/2022	avian_flu	EPI_ISL_17558875	2022-12-27	North America	Honduras	Departamento de Atlantida	NA	Wild bird	Wild
 EPI2455169|BC90_H5.1	A/great_egret/Czech_Republic/3051-2orig/2023	avian_flu	EPI_ISL_17164994	2023-02-21	Europe	Czech Republic	South Moravian Region	Okres Brno-Venkov	Wild bird	Wild
 EPI2455161|BC79[H5]	A/great_egret/Czech_Republic/3051-1orig/2023	avian_flu	EPI_ISL_17164993	2023-02-21	Europe	Czech Republic	South Moravian Region	Okres Brno-Venkov	Wild bird	Wild
-EPI2441729|A/Pelecanus/Peru/VFAR-140/2022	A/Pelecanus/Peru/VFAR-140/2022	avian_flu	EPI_ISL_17099964	2022-12-01	South America	Peru	Departamento de Ica	Beaches of the Tambo de Mora (Chincha Alta/Chincha/Ica/Peru),	Wild bird	Wild
 EPI2311407|27282|22MM00199|HA	A/great horned owl/MA/22MM00199/2022	avian_flu	EPI_ISL_16641778	2022-03-03	North America	United States	Massachusetts	Middlesex County	Wild bird	NA
 EPI2311343|27273|22HP00137|HA	A/herring gull/MA/22HP00137/2022	avian_flu	EPI_ISL_16641770	2022-03-07	North America	United States	Massachusetts	Barnstable county	Larus smithsonianus	NA
 EPI2801205|A/grey_goose/Austria/23139868-001/2023	A/grey_goose/Austria/23139868-001/2023	avian_flu	EPI_ISL_18540525	2023-10-23	Europe	Austria	Lower Austria	Amstetten	Greylag goose	Wild
@@ -11965,14 +11934,11 @@ EPI2311447|31288|22MM00823|HA	A/common eider/MA/22MM00823/2022	avian_flu	EPI_ISL
 EPI2311439|31306|22MM00772|HA	A/common eider/MA/22MM00772/2022	avian_flu	EPI_ISL_16641782	2022-06-19	North America	United States	Massachusetts	Essex County	Somateria mollissima	NA
 EPI2311431|31302|22MM00763|HA	A/common eider/MA/22MM00763/2022	avian_flu	EPI_ISL_16641781	2022-06-17	North America	United States	Massachusetts	Essex County	Somateria mollissima	NA
 EPI2311423|31311|22MM00724|HA	A/common eider/MA/22MM00724/2022	avian_flu	EPI_ISL_16641780	2022-06-13	North America	United States	Massachusetts	NA	Somateria mollissima	NA
-EPI2500057|A/Turkey/ON/FAV-0162-144/2022	A/Turkey/ON/FAV-0162-144/2022	avian_flu	EPI_ISL_17394089	2022-03-25	North America	Canada	Ontario	NA	Meleagris gallopavo	Domestic
 EPI2085994|220413_52_96_H5N1_Seg4_HA	A/turkey/Stavropol/211-9V/2022	avian_flu	EPI_ISL_13692629	2022-02-01	Europe	Russian Federation	Stavropol Krai	NA	Meleagris gallopavo	NA
 EPI2085986|220413_52_95_H5N1_Seg4_HA	A/turkey/Stavropol/211-5V/2022	avian_flu	EPI_ISL_13692628	2022-02-01	Europe	Russian Federation	Stavropol Krai	NA	Meleagris gallopavo	NA
 EPI2085978|220413_52_94_H5N1_Seg4_HA	A/turkey/Stavropol/211-18V/2022	avian_flu	EPI_ISL_13692627	2022-02-01	Europe	Russian Federation	Stavropol Krai	NA	Meleagris gallopavo	NA
-EPI2085970|220413_52_93_H5N1_Seg4_HA	A/turkey/Stavropol/211-18V/2022	avian_flu	EPI_ISL_13692626	2022-02-01	Europe	Russian Federation	Stavropol Krai	NA	Meleagris gallopavo	NA
 EPI2085962|220413_52_92_H5N1_Seg4_HA	A/turkey/Stavropol/211-15V/2022	avian_flu	EPI_ISL_13692625	2022-02-01	Europe	Russian Federation	Stavropol Krai	NA	Meleagris gallopavo	NA
 EPI2085954|220413_52_91_H5N1_Seg4_HA	A/turkey/Stavropol/211-12V/2022	avian_flu	EPI_ISL_13692624	2022-02-01	Europe	Russian Federation	Stavropol Krai	NA	Meleagris gallopavo	NA
-EPI2085946|220413_52_90_H5N1_Seg4_HA	A/turkey/Stavropol/211-12V/2022	avian_flu	EPI_ISL_13692623	2022-02-01	Europe	Russian Federation	Stavropol Krai	NA	Meleagris gallopavo	NA
 EPI2085938|220413_52_89_H5N1_Seg4_HA	A/turkey/Stavropol/211-7V/2022	avian_flu	EPI_ISL_13692622	2022-02-01	Europe	Russian Federation	Stavropol Krai	NA	Meleagris gallopavo	NA
 EPI2085930|220413_52_88_H5N1_Seg4_HA	A/turkey/Stavropol/211-4V/2022	avian_flu	EPI_ISL_13692621	2022-02-01	Europe	Russian Federation	Stavropol Krai	NA	Meleagris gallopavo	NA
 EPI2085922|220413_52_87_H5N1_Seg4_HA	A/turkey/Stavropol/211-1V/2022	avian_flu	EPI_ISL_13692620	2022-02-01	Europe	Russian Federation	Stavropol Krai	NA	Meleagris gallopavo	NA
@@ -11982,11 +11948,8 @@ EPI2311367|27276|22HP00150|HA	A/american crow/MA/22HP00150/2022	avian_flu	EPI_IS
 EPI2311359|27275|22HP00149|HA	A/american crow/MA/22HP00149/2022	avian_flu	EPI_ISL_16641772	2022-03-15	North America	United States	Massachusetts	Barnstable county	Crow	NA
 EPI2311351|27274|22HP00148|HA	A/american crow/MA/22HP00148/2022	avian_flu	EPI_ISL_16641771	2022-03-15	North America	United States	Massachusetts	Barnstable county	Crow	NA
 EPI2086042|220519_60_73_H5N1_Seg4_HA	A/crow/Khabarovsk/216-13V/2022	avian_flu	EPI_ISL_13692635	2022-04-21	Europe	Russian Federation	Khabarovsk Krai	NA	Crow	NA
-EPI2086034|220519_60_72_H5N1_Seg4_HA	A/crow/Khabarovsk/216-13V/2022	avian_flu	EPI_ISL_13692634	2022-04-21	Europe	Russian Federation	Khabarovsk Krai	NA	Crow	NA
 EPI2086026|220519_60_71_H5N1_Seg4_HA	A/crow/Khabarovsk/216-12V/2022	avian_flu	EPI_ISL_13692633	2022-04-21	Europe	Russian Federation	Khabarovsk Krai	NA	Crow	NA
-EPI2086018|220519_60_70_H5N1_Seg4_HA	A/crow/Khabarovsk/216-12V/2022	avian_flu	EPI_ISL_13692632	2022-04-21	Europe	Russian Federation	Khabarovsk Krai	NA	Crow	NA
 EPI2086010|220519_60_69_H5N1_Seg4_HA	A/crow/Khabarovsk/216-11V/2022	avian_flu	EPI_ISL_13692631	2022-04-21	Europe	Russian Federation	Khabarovsk Krai	NA	Crow	NA
-EPI2086002|220519_60_68_H5N1_Seg4_HA	A/crow/Khabarovsk/216-11V/2022	avian_flu	EPI_ISL_13692630	2022-04-21	Europe	Russian Federation	Khabarovsk Krai	NA	Crow	NA
 EPI2028974|2022-wk19-06_HA_H5	A/great crested grebe/Netherlands/22005666-001/2022	avian_flu	EPI_ISL_12512578	2022-03-21	Europe	Netherlands	Provincie Gelderland	NA	Podiceps cristatus	NA
 EPI2086058|220519_60_67_H5N1_Seg4_HA	A/dalmatian pelican/Astrakhan/213-2V/2022	avian_flu	EPI_ISL_13692638	2022-03-14	Europe	Russian Federation	Astrakhan Oblast	NA	Wild waterfowl	NA
 EPI2086050|220519_60_66_H5N1_Seg4_HA	A/dalmatian pelican/Astrakhan/213-1V/2022	avian_flu	EPI_ISL_13692637	2022-03-14	Europe	Russian Federation	Astrakhan Oblast	NA	Wild waterfowl	NA
@@ -12196,7 +12159,6 @@ EPI2236509|A/Red Fox/PEI/FAV-0591-02/2022	A/Red Fox/PEI/FAV-0591-02/2022	avian_f
 EPI2236495|A/Red Fox/PEI/FAV-0591-01/2022	A/Red Fox/PEI/FAV-0591-01/2022	avian_flu	EPI_ISL_16020774	2022-05-24	North America	Canada	Prince Edward Island	NA	Other mammals	Wild
 EPI2236487|A/Red Fox/PEI/FAV-0544/2022	A/Red Fox/PEI/FAV-0544/2022	avian_flu	EPI_ISL_16020773	2022-05-19	North America	Canada	Prince Edward Island	NA	Other mammals	Wild
 EPI2236479|A/Red Fox/PEI/FAV-0592-02/2022	A/Red Fox/PEI/FAV-0592-02/2022	avian_flu	EPI_ISL_16020772	2022-05-24	North America	Canada	Prince Edward Island	NA	Other mammals	Wild
-EPI2181752|A/bottlenose dolphin/UFTt2203/2022	A/bottlenose dolphin/Florida/UFTt2203/2022	avian_flu	EPI_ISL_15069397	2022-03-30	North America	United States	Florida	Dixie County	Other mammals	Wild
 EPI3338219|A/environment/Chile/C64558/2023_HA	A/environment/Chile/C64558/2023	avian_flu	EPI_ISL_19167955	2023-07-19	South America	Chile	NA	NA	Environment	NA
 EPI3338005|A/environment/Chile/C62069/2022_HA	A/environment/Chile/C62069/2022	avian_flu	EPI_ISL_19167926	2022-12-27	South America	Chile	NA	NA	Environment	NA
 EPI3337997|A/environment/Chile/C62068/2022_HA	A/environment/Chile/C62068/2022	avian_flu	EPI_ISL_19167925	2022-12-27	South America	Chile	NA	NA	Environment	NA
@@ -12236,14 +12198,11 @@ EPI2147698|A/Bulbucus ibis/Spain/343-4/2022	A/Bulbucus ibis/Spain/343-4/2022	avi
 EPI2147694|A/Ardea cinerea/Spain/88-2/2022	A/Ardea cinerea/Spain/88-2/2022	avian_flu	EPI_ISL_14776055	2022-01-11	Europe	Spain	NA	NA	Host	NA
 EPI3437006|3016023834_ZZYW1LF2_v1_4	A/Colorado/109/2024	avian_flu	EPI_ISL_19263923	2024-07-11	North America	United States	Colorado	NA	Human	NA
 EPI2804266|A/Cambodia/2311257/2023	A/Cambodia/2311257/2023	avian_flu	EPI_ISL_18543643	2023-11-24	Asia	Cambodia	Khett Kampot	NA	Human	NA
-EPI2804262|2311257|HA	A/Cambodia/2311257/2023	avian_flu	EPI_ISL_18543642	2023-11-24	Asia	Cambodia	Khett Kampot	NA	Human	NA
-EPI2804247|A/Cambodia/KSH230332/2023	A/Cambodia/KSH230332/2023	avian_flu	EPI_ISL_18543355	2023-11-23	Asia	Cambodia	Krong Phnum Penh	NA	Human	NA
 EPI2436447|A/Cambodia/2302009/2023	A/Cambodia/2302009/2023	avian_flu	EPI_ISL_17069010	2023-02-23	Asia	Cambodia	Krong Phnum Penh	NA	Human	NA
 EPI2807456|A/Caspian tern/Astrakhan/38/2022	A/Caspian tern/Astrakhan/38/2022	avian_flu	EPI_ISL_16020405	2022-05-15	Europe	Russian Federation	NA	NA	Animal	NA
 EPI3438900|A/raven/Khabarovsk Krai/3414/2022_HA	A/raven/Khabarovsk Krai/3414/2022	avian_flu	EPI_ISL_19266396	2022-11-15	Europe	Russian Federation	Khabarovsk Krai	Komsomolsk-na-Amure	Avian	NA
 EPI3438884|A/raven/Khabarovsk Krai/3413/2022_HA	A/raven/Khabarovsk Krai/3413/2022	avian_flu	EPI_ISL_19266394	2022-11-15	Europe	Russian Federation	Khabarovsk Krai	Komsomolsk-na-Amure	Avian	NA
 EPI3338496|A/red-tailed_hawk/California/24-003714-001/2024_HA	A/red-tailed_hawk/California/24-003714-001/2024	avian_flu	EPI_ISL_19168060	2024-01-27	North America	United States	California	NA	Avian	NA
-EPI3335934|A/Peregrine falcon/Netherlands/1/2022_HA_HPAI	A/Peregrine falcon/Netherlands/1/2022	avian_flu	EPI_ISL_19165890	2022-10-26	Europe	Netherlands	Terschelling	NA	Avian	NA
 EPI3335927|A/Eurasian sparrowhawk/Netherlands/1/2024_HA_HPAI	A/Eurasian sparrowhawk/Netherlands/1/2024	avian_flu	EPI_ISL_19165889	2024-02-04	Europe	Netherlands	Vlieland	NA	Avian	NA
 EPI3280483|A/Black_faced_Spoonbill/AFCD-HKU-22-21944-01009/2022	A/Black_faced_Spoonbill/AFCD-HKU-22-21944-01009/2022	avian_flu	EPI_ISL_19135474	2022-12-06	Asia	Hong Kong (SAR)	NA	NA	Avian	NA
 EPI3280377|A/American white pelican/North Carolina/W24-84/2024_HA	A/American white pelican/North Carolina/W24-84/2024	avian_flu	EPI_ISL_19134613	2024-01-23	North America	United States	North Carolina	NA	Avian	NA
@@ -12277,10 +12236,8 @@ EPI2899582|HA A/turkey/South Dakota/23-036898-001-original/2023(H5N1)	A/turkey/S
 EPI2899574|HA A/turkey/Minnesota/23-036928-002-original/2023(H5N1)	A/turkey/Minnesota/23-036928-002/2023	avian_flu	EPI_ISL_18741779	2023-11-20	North America	United States	Minnesota	Stearns County	Avian	NA
 EPI2899566|HA A/turkey/Minnesota/23-036928-001-original/2023(H5N1)	A/turkey/Minnesota/23-036928-001/2023	avian_flu	EPI_ISL_18741778	2023-11-20	North America	United States	Minnesota	Stearns County	Avian	NA
 EPI2899550|HA A/turkey/Minnesota/23-036929-001-original/2023(H5N1)	A/turkey/Minnesota/23-036929-001/2023	avian_flu	EPI_ISL_18741776	2023-11-19	North America	United States	Minnesota	Otter Tail Country	Avian	NA
-EPI2899542|HA A/turkey/Missouri/23-034952-002-original/2023(H5N1)	A/turkey/Missouri/23-034952-002/2023	avian_flu	EPI_ISL_18741775	2023-11-10	North America	United States	Missouri	Jasper County	Avian	NA
 EPI2898969|A/large-billed crow/Hokkaido/20231207001/2023	A/large-billed crow/Hokkaido/20231207001/2023	avian_flu	EPI_ISL_18740266	2023-12-07	Asia	Japan	Hokkaido	Kushiro	Avian	Wild
 EPI2898953|A/large-billed crow/Hokkaido/0112Q104/2023	A/large-billed crow/Hokkaido/0112Q104/2023	avian_flu	EPI_ISL_18740128	2023-12-01	Asia	Japan	Hokkaido	Nemuro	Avian	Wild
-EPI2898788|A/goshawk/Gifu/1/2023	A/goshawk/Gifu/1/2023	avian_flu	EPI_ISL_18740020	2023-11-23	Asia	Japan	Gifu	Kaizu	Avian	Domestic
 EPI2841125|A/large-billed crow/Hokkaido/0111Q100/2023	A/large-billed crow/Hokkaido/0111Q100/2023	avian_flu	EPI_ISL_18640907	2023-11-22	Asia	Japan	Hokkaido	Shibetsu	Avian	Wild
 EPI2780770|A/Nothern_gannet/France/22P019694/2022_HA	A/Nothern_gannet/France/22P019694/2022	avian_flu	EPI_ISL_18445751	2022-07-25	Europe	France	NA	NA	Avian	NA
 EPI2780762|A/Herring_gull/France/22P019691/2022_HA	A/Herring_gull/France/22P019691/2022	avian_flu	EPI_ISL_18445750	2022-07-23	Europe	France	NA	NA	Avian	NA
@@ -12551,13 +12508,6 @@ EPI2029075|A/Common raven/Netherlands/1/2022_HA_H5N1_HPAI	A/Common raven/Netherl
 EPI2029067|A/Caspian Gull/Netherlands/3/2022_HA_H5N1_HPAI	A/Caspian Gull/Netherlands/3/2022	avian_flu	EPI_ISL_12514483	2022-04-14	Europe	Netherlands	De Kreupel	NA	Avian	NA
 EPI2029059|A/Black-headed gull/Netherlands/4/2022_HA_H5N1_HPAI	A/Black-headed gull/Netherlands/4/2022	avian_flu	EPI_ISL_12514442	2022-04-14	Europe	Netherlands	De Kreupel	NA	Avian	NA
 EPI2029051|A/Black-headed gull/Netherlands/3/2022_HA_H5N1_HPAI	A/Black-headed gull/Netherlands/3/2022	avian_flu	EPI_ISL_12514425	2022-04-14	Europe	Netherlands	De Kreupel	NA	Avian	NA
-EPI2008853|Seq332	A/turkey/Iowa/22-006795-002/2022	avian_flu	EPI_ISL_11628252	2022-03-06	North America	United States	Iowa	Buena Vista	Avian	NA
-EPI2008845|Seq324	A/turkey/Iowa/22-006795-001/2022	avian_flu	EPI_ISL_11628251	2022-03-06	North America	United States	Iowa	Buena Vista	Avian	NA
-EPI2008837|Seq316	A/turkey/South Dakota/22-006792-002/2022	avian_flu	EPI_ISL_11628250	2022-03-04	North America	United States	South Dakota	Charles Mix	Avian	NA
-EPI2008829|Seq308	A/turkey/South Dakota/22-006792-001/2022	avian_flu	EPI_ISL_11628249	2022-03-04	North America	United States	South Dakota	Charles	Avian	NA
-EPI2008821|Seq300	A/chicken/Missouri/22-006639-001/2022	avian_flu	EPI_ISL_11628248	2022-03-03	North America	United States	Missouri	Bates	Avian	NA
-EPI2008813|Seq292	A/chicken/Maryland/22-006578-002/2022	avian_flu	EPI_ISL_11628247	2022-03-03	North America	United States	Maryland	Cecil	Avian	NA
-EPI2008805|Seq284	A/chicken/Maryland/22-006578-001/2022	avian_flu	EPI_ISL_11628246	2022-03-03	North America	United States	Maryland	Cecil	Avian	NA
 EPI2008797|Seq276	A/chicken/Missouri/22-006569-002/2022	avian_flu	EPI_ISL_11628245	2022-03-02	North America	United States	Missouri	Stoddard	Avian	NA
 EPI2008789|Seq268	A/chicken/Missouri/22-006569-001/2022	avian_flu	EPI_ISL_11628244	2022-03-02	North America	United States	Missouri	Stoddard	Avian	NA
 EPI2008781|Seq260	A/turkey/Indiana/22-006261-002/2022	avian_flu	EPI_ISL_11628243	2022-03-01	North America	United States	Indiana	Dubois	Avian	NA
@@ -12805,7 +12755,6 @@ EPI2232970|A/domestic_goose/England/146384/2022|HA	A/domestic_goose/England/1463
 EPI2232922|A/Domestic_Goose/England/145097/2022|HA	A/Domestic_Goose/England/145097/2022	avian_flu	EPI_ISL_15957844	2022-11-03	Europe	United Kingdom	England	NA	Goose	NA
 EPI2232738|A/domestic_goose/England/138821/2022|HA	A/domestic_goose/England/138821/2022	avian_flu	EPI_ISL_15957684	2022-10-22	Europe	United Kingdom	England	NA	Goose	NA
 EPI2475301|A/Canada_goose/England/394558/2022|HA	A/Canada_goose/England/394558/2022	avian_flu	EPI_ISL_17268133	2022-10-21	Europe	United Kingdom	England	NA	Goose	NA
-EPI3371826|A/lesser black-backed gull/Netherlands/22012469-002/2022	A/lesser black-backed gull/Netherlands/22012469-002/2022	avian_flu	EPI_ISL_19201535	2022-07-14	Europe	Netherlands	South Holland	NA	Larus fuscus	Wild
 EPI2810206|A_pheasant_Denmark_08786-1_2023-11-20	A/pheasant/Denmark/08786-1/2023-11-20	avian_flu	EPI_ISL_18578957	2023-11-20	Europe	Denmark	Region Syddanmark	Tonder Kommune	Pheasant	Domestic
 EPI2820597|A/swan/Romania/15974_23VIR10497-4/2023_HA	A/swan/Romania/15974_23VIR10497-4/2023	avian_flu	EPI_ISL_18612182	2023-10-30	Europe	Romania	NA	NA	Swan	NA
 EPI2820589|A/swan/Romania/15862_23VIR10497-3/2023_HA	A/swan/Romania/15862_23VIR10497-3/2023	avian_flu	EPI_ISL_18612181	2023-10-25	Europe	Romania	NA	NA	Swan	NA
@@ -12953,7 +12902,6 @@ EPI2747674|A-chicken-Hokkaido-22B3C-2022_S28(ha)	A/chicken/Hokkaido/22B3C/2022	a
 EPI2747666|A-chicken-Hokkaido-22A4T-2022_S11(ha)	A/chicken/Hokkaido/22A4T/2022	avian_flu	EPI_ISL_18284461	2022-10-28	Asia	Japan	NA	NA	Chicken	NA
 EPI2475293|A/chicken/England/152082/2022|HA	A/chicken/England/152082/2022	avian_flu	EPI_ISL_17268132	2022-11-14	Europe	United Kingdom	England	NA	Chicken	NA
 EPI2233122|A/Domestic_Duck/England/144945/2022|HA	A/Domestic_Duck/England/144945/2022	avian_flu	EPI_ISL_15958011	2022-11-03	Europe	United Kingdom	England	NA	Duck	NA
-EPI2233114|A/domestic_duck/England/2022|HA	A/domestic_duck/England/152473/2022	avian_flu	EPI_ISL_15958004	2022-11-15	Europe	United Kingdom	England	NA	Duck	NA
 EPI2232962|A/domestic_duck/England/146319/2022|HA	A/domestic_duck/England/146319/2022	avian_flu	EPI_ISL_15957878	2022-11-05	Europe	United Kingdom	England	NA	Duck	NA
 EPI2232826|A/Domestic_Duck/England/141951/2022|HA	A/Domestic_Duck/England/141951/2022	avian_flu	EPI_ISL_15957766	2022-10-29	Europe	United Kingdom	England	NA	Duck	NA
 EPI2232786|A/domestic_duck/England/141358/2022|HA	A/domestic_duck/England/141358/2022	avian_flu	EPI_ISL_15957722	2022-10-26	Europe	United Kingdom	England	NA	Duck	NA
@@ -13943,7 +13891,6 @@ EPI6629|A/Environment/Hong_Kong/437-8/99	A/Environment/Hong Kong/437-8/99	avian_
 EPI6611|A/Environment/Hong_Kong/437-6/99	A/Environment/Hong Kong/437-6/99	avian_flu	EPI_ISL_1460	NA	Asia	China	NA	NA	Environment	NA
 EPI6593|A/Environment/Hong_Kong/437-4/99	A/Environment/Hong Kong/437-4/99	avian_flu	EPI_ISL_1459	NA	Asia	China	NA	NA	Environment	NA
 EPI2012875|A/Eurasian_wigeon/Denmark/24066-9/2021-10-13	A/Eurasian_wigeon/Denmark/24066-9/2021-10-13	avian_flu	EPI_ISL_11798572	2021-10-13	Europe	Denmark	Region Syddanmark	Tonder Kommune	Feces	Wild
-EPI824045|A/chicken/Yamaguchi/7/2004, EPI824046|A/chicken/Yamaguchi/7/2004	A/chicken/Yamaguchi/7/2004	avian_flu	EPI_ISL_231797	NA	Asia	Japan	NA	NA	Laboratory derived	NA
 EPI234713|A/Ck/Indonesia/PA/2003	A/Ck/Indonesia/PA/2003	avian_flu	EPI_ISL_67168	NA	Asia	Indonesia	NA	NA	Unknown	NA
 EPI234705|A/Ck/Indonesia/BL/2003	A/Ck/Indonesia/BL/2003	avian_flu	EPI_ISL_67167	NA	Asia	Indonesia	NA	NA	Unknown	NA
 NA	A/Thailand/NA60/2005	avian_flu	EPI_ISL_67075	NA	Asia	Thailand	NA	NA	Unknown	NA
@@ -14785,12 +14732,10 @@ EPI2035708|07S1138	A/ Duck/Ha Tinh/NCVD-54/2007	avian_flu	EPI_ISL_12701625	NA	As
 EPI2035705|07S1137	A/ Duck/Ha Tinh/NCVD-53/2007	avian_flu	EPI_ISL_12701624	NA	Asia	Vietnam	Nam Ha Tinh	NA	Avian	NA
 EPI2035692|07S0652	A/Muscovy Duck/Indonesia/1631-53/2006	avian_flu	EPI_ISL_12700689	2006-12-01	Asia	Indonesia	NA	NA	Avian	NA
 EPI2035597|07S0656	A/Swine/Timika/BBVM186B/2007	avian_flu	EPI_ISL_12700622	NA	Asia	Indonesia	West Papua	NA	Avian	NA
-EPI2035594|07S0434	A/Swan/Indonesia/Malang1631-61/2007	avian_flu	EPI_ISL_12700621	2007-02-01	Asia	Indonesia	East Java	NA	Avian	NA
 EPI2035574|07S0773	A/Quail/Jombang/P2kh/2005	avian_flu	EPI_ISL_12700604	NA	Asia	Indonesia	East Java	NA	Avian	NA
 EPI2035571|07S0080	A/Quail/Jakarta/Ju1/2006	avian_flu	EPI_ISL_12700603	2006-08-01	Asia	Indonesia	NA	NA	Avian	NA
 EPI2035568|07S0650	A/Quail/Indonesia/Bantul1631-40/2006	avian_flu	EPI_ISL_12700602	2006-09-01	Asia	Indonesia	Bangka-Belitung	NA	Avian	NA
 EPI2035565|07S0072	A/Quail/Central Java/SMRG/2006	avian_flu	EPI_ISL_12700601	2006-06-01	Asia	Indonesia	Central Java	NA	Avian	NA
-EPI2035562|07S0418	A/Pigeon/Indonesia/Rokhit1631-6/2006	avian_flu	EPI_ISL_12700600	2006-10-01	Asia	Indonesia	NA	NA	Avian	NA
 EPI2035507|07S0102	A/Muscovy Duck/Vietnam/Ben Tre/342/2006	avian_flu	EPI_ISL_12700572	2006-07-21	Asia	Vietnam	Tinh Ben Tre	NA	Avian	NA
 EPI2035504|07S0085	A/Muscovy Duck/Jakarta/HABWIN/2006	avian_flu	EPI_ISL_12700571	2006-09-01	Asia	Indonesia	NA	NA	Avian	NA
 EPI2035501|07S0777	A/Muscovy Duck/Bone/BBVM170/2007	avian_flu	EPI_ISL_12700570	NA	Asia	Indonesia	NA	NA	Avian	NA
@@ -15002,10 +14947,6 @@ EPI153805|A/chicken/Nigeria/VRD203/2006	A/chicken/Nigeria/VRD203/2006	avian_flu	
 EPI153804|A/chicken/Nigeria/VRD200/2006	A/chicken/Nigeria/VRD200/2006	avian_flu	EPI_ISL_19641	NA	Africa	Nigeria	NA	NA	Chicken	NA
 EPI153803|A/chicken/Nigeria/VRD145/2006	A/chicken/Nigeria/VRD145/2006	avian_flu	EPI_ISL_19640	NA	Africa	Nigeria	NA	NA	Chicken	NA
 EPI153802|A/chicken/Nigeria/VRD130b/2006	A/chicken/Nigeria/VRD130b/2006	avian_flu	EPI_ISL_19639	NA	Africa	Nigeria	NA	NA	Chicken	NA
-EPI153489|A/chicken/Egypt/1709-6/2008	A/chicken/Egypt/1709-6/2008	avian_flu	EPI_ISL_19586	NA	Africa	Egypt	NA	NA	Chicken	NA
-EPI153488|A/chicken/Egypt/1709-5/2008	A/chicken/Egypt/1709-5/2008	avian_flu	EPI_ISL_19585	NA	Africa	Egypt	NA	NA	Chicken	NA
-EPI153487|A/chicken/Egypt/1709-4VIR08/2007	A/chicken/Egypt/1709-4VIR08/2007	avian_flu	EPI_ISL_19584	NA	Africa	Egypt	NA	NA	Chicken	NA
-EPI153485|A/chicken/Egypt/1709-1VIR08/2007	A/chicken/Egypt/1709-1VIR08/2007	avian_flu	EPI_ISL_19582	NA	Africa	Egypt	NA	NA	Chicken	NA
 EPI153471|A/chicken/Laos/1/2008	A/chicken/Laos/1/2008	avian_flu	EPI_ISL_19571	NA	Asia	Lao, People's Democratic Republic	NA	NA	Chicken	NA
 EPI22749|A/Ck/Thailand/73/2004, EPI82234|A/Ck/Thailand/73/2004	A/Ck/Thailand/73/2004	avian_flu	EPI_ISL_4149	NA	Asia	Thailand	NA	NA	Chicken	NA
 EPI22747|A/Ck/Thailand/1/2004	A/Ck/Thailand/1/2004	avian_flu	EPI_ISL_4148	NA	Asia	Thailand	NA	NA	Chicken	NA
@@ -15213,8 +15154,6 @@ EPI416765|A/duck/Sleman/BBVW-1463-10/2012	A/duck/Sleman/BBVW-1463-10/2012	avian_
 EPI416764|A/duck/Bantul/BBVW-1443-9/2012	A/duck/Bantul/BBVW-1443-9/2012	avian_flu	EPI_ISL_134258	2012-09-27	Asia	Indonesia	NA	NA	Duck	NA
 EPI416763|A/duck/Sukoharjo/BBVW-1428-9/2012	A/duck/Sukoharjo/BBVW-1428-9/2012	avian_flu	EPI_ISL_134257	2012-09-25	Asia	Indonesia	NA	NA	Duck	NA
 NA	A/wild duck/Korea/SNU50-5/2009	avian_flu	EPI_ISL_134110	2009-09-27	Asia	Korea, Republic of	NA	NA	Duck	Wild
-EPI416368|A/wild duck/Korea/SNU50-5/2009	A/wild duck/Korea/SNU50-5/2009	avian_flu	EPI_ISL_134109	2009-09-27	Asia	Korea, Republic of	NA	NA	Duck	Wild
-EPI416362|A/wild duck/Korea/SNU50-5/2009	A/wild duck/Korea/SNU50-5/2009	avian_flu	EPI_ISL_134108	2009-09-27	Asia	Korea, Republic of	NA	NA	Duck	Wild
 EPI369190|A/duck/Egypt/11762s/2011	A/duck/Egypt/11762s/2011	avian_flu	EPI_ISL_117771	2011-11-29	Africa	Egypt	NA	NA	Duck	NA
 EPI369188|A/duck/Egypt/1187/2011	A/duck/Egypt/1187/2011	avian_flu	EPI_ISL_117769	2011-10-22	Africa	Egypt	Giza	NA	Duck	NA
 EPI369186|A/duck/Egypt/11685s/2011	A/duck/Egypt/11685s/2011	avian_flu	EPI_ISL_117767	2011-08-22	Africa	Egypt	NA	NA	Duck	NA
@@ -15226,7 +15165,6 @@ EPI237960|A/duck/Hong Kong/2986.1-2/2000	A/duck/Hong Kong/2986.1-2/2000	avian_fl
 NA	A/duck/Egypt/1709-3VIR08/2007	avian_flu	EPI_ISL_20067	NA	Africa	Egypt	NA	NA	Duck	NA
 EPI154509|6732-7HA	A/duck/Saudi Arabia/6732-7/2007	avian_flu	EPI_ISL_19927	NA	Asia	Saudi Arabia	NA	NA	Duck	NA
 EPI153819|A/duck/Nigeria/VRD418/2006	A/duck/Nigeria/VRD418/2006	avian_flu	EPI_ISL_19656	NA	Africa	Nigeria	NA	NA	Duck	NA
-EPI153486|A/duck/Egypt/1709-3VIR08/2007	A/duck/Egypt/1709-3VIR08/2007	avian_flu	EPI_ISL_19583	NA	Africa	Egypt	NA	NA	Duck	NA
 EPI21094|A/duck/Zhejiang/52/2000	A/duck/Zhejiang/52/2000	avian_flu	EPI_ISL_3909	NA	Asia	China	Zhejiang Province	NA	Duck	NA
 EPI21092|A/duck/Shanghai/38/2001	A/duck/Shanghai/38/2001	avian_flu	EPI_ISL_3908	NA	Asia	China	NA	NA	Duck	NA
 EPI21090|A/duck/Guangxi/50/2001	A/duck/Guangxi/50/2001	avian_flu	EPI_ISL_3907	NA	Asia	China	Guangxi Zhuang Autonomous Region	NA	Duck	NA
@@ -15269,7 +15207,6 @@ EPI14156|A/duck/Romania/2/05	A/duck/Romania/2/05	avian_flu	EPI_ISL_2956	NA	Europ
 EPI13980|A/duck/Vietnam/TG24-O1/05	A/duck/Vietnam/TG24-O1/05	avian_flu	EPI_ISL_2924	NA	Asia	Vietnam	NA	NA	Duck	NA
 EPI13978|A/duck/Vietnam/AG40-O2/05	A/duck/Vietnam/AG40-O2/05	avian_flu	EPI_ISL_2923	NA	Asia	Vietnam	NA	NA	Duck	NA
 EPI13976|A/duck/Vietnam/TG36-H2/05	A/duck/Vietnam/TG36-H2/05	avian_flu	EPI_ISL_2922	NA	Asia	Vietnam	NA	NA	Duck	NA
-EPI13881|A/duck/France/05066b/2005	A/duck/France/05066b/2005	avian_flu	EPI_ISL_2890	NA	Europe	France	NA	NA	Duck	NA
 EPI1957839|211217_26_H5N1_Seg4_HA	A/duck/Omsk/19-5V/2021	avian_flu	EPI_ISL_8768966	2021-09-24	Europe	Russian Federation	Omsk Oblast	Omsk	Anas platyrhynchos	NA
 EPI1957830|211217_25_H5N1_Seg4_HA	A/duck/Omsk/19-3V/2021	avian_flu	EPI_ISL_8768965	2021-09-24	Europe	Russian Federation	Omsk Oblast	Omsk	Anas platyrhynchos	NA
 EPI1957822|211217_24_H5N1_Seg4_HA	A/duck/Omsk/19-2V/2021	avian_flu	EPI_ISL_8768955	2021-09-24	Europe	Russian Federation	Omsk Oblast	Omsk	Anas platyrhynchos	NA
@@ -15328,26 +15265,21 @@ EPI2017747|A/chicken/Botswana/2163-B/2021|HA	A/chicken/Botswana/2163-B/2021	avia
 EPI1966001|A/Gallus_gallus/Belgium/17100_0001/2021	A/Gallus_gallus/Belgium/17100_0001/2021	avian_flu	EPI_ISL_9161618	2021-12-27	Europe	Belgium	Provincie West-Vlaanderen	Veurne	Gallus gallus domesticus	Domestic
 EPI1958145|211217_64_H5N1_Seg4_HA	A/chicken/Saratov/102-15V/2021	avian_flu	EPI_ISL_8769038	2021-11-04	Europe	Russian Federation	Saratov Oblast	Saratov	Gallus gallus domesticus	NA
 EPI1958137|211217_63_H5N1_Seg4_HA	A/chicken/Saratov/102-12V/2021	avian_flu	EPI_ISL_8769037	2021-11-04	Europe	Russian Federation	Saratov Oblast	Saratov	Gallus gallus domesticus	NA
-EPI1958129|211217_62_H5N1_Seg4_HA	A/chicken/Saratov/102-12V/2021	avian_flu	EPI_ISL_8769036	2021-10-13	Europe	Russian Federation	Saratov Oblast	Saratov	Gallus gallus domesticus	NA
 EPI1958113|211217_60_H5N1_Seg4_HA	A/chicken/Tyumen/81-97V/2021	avian_flu	EPI_ISL_8769034	2021-10-30	Europe	Russian Federation	Tyumen Oblast	Tyumen	Gallus gallus domesticus	NA
 EPI1958081|211217_56_H5N1_Seg4_HA	A/chicken/Orenburg/73-7V/2021	avian_flu	EPI_ISL_8769030	2021-10-27	Europe	Russian Federation	Orenburg Oblast	Orenburg	Gallus gallus domesticus	NA
 EPI1958073|211217_55_H5N1_Seg4_HA	A/chicken/Orenburg/73-6V/2021	avian_flu	EPI_ISL_8769029	2021-10-27	Europe	Russian Federation	Orenburg Oblast	Orenburg	Gallus gallus domesticus	NA
 EPI1958065|211217_54_H5N1_Seg4_HA	A/chicken/Orenburg/73-5V/2021	avian_flu	EPI_ISL_8769028	2021-10-27	Europe	Russian Federation	Orenburg Oblast	Orenburg	Gallus gallus domesticus	NA
 EPI1958057|211217_53_H5N1_Seg4_HA	A/chicken/Kurgan/72-1V/2021	avian_flu	EPI_ISL_8769027	2021-10-22	Europe	Russian Federation	Kurgan Oblast	Kurgan	Gallus gallus domesticus	NA
-EPI1958049|211217_52_H5N1_Seg4_HA	A/chicken/Kurgan/72-1V/2021	avian_flu	EPI_ISL_8769026	2021-10-22	Europe	Russian Federation	Kurgan Oblast	Kurgan	Gallus gallus domesticus	NA
 EPI1958041|211217_51_H5N1_Seg4_HA	A/chicken/Kirov/63-5V/2021	avian_flu	EPI_ISL_8769025	2021-10-27	Europe	Russian Federation	Kirov Oblast	Kirov	Gallus gallus domesticus	NA
 EPI1958033|211217_50_H5N1_Seg4_HA	A/chicken/Kirov/63-2V/2021	avian_flu	EPI_ISL_8769024	2021-10-27	Europe	Russian Federation	Kirov Oblast	Kirov	Gallus gallus domesticus	NA
 EPI1958025|211217_49_H5N1_Seg4_HA	A/chicken/Kirov/63-1V/2021	avian_flu	EPI_ISL_8769023	2021-10-27	Europe	Russian Federation	Kirov Oblast	Kirov	Gallus gallus domesticus	NA
 EPI1958017|211217_48_H5N1_Seg4_HA	A/chicken/Tyumen/47-95V/2021	avian_flu	EPI_ISL_8769022	2021-10-12	Europe	Russian Federation	Tyumen Oblast	Tyumen	Gallus gallus domesticus	NA
 EPI1958009|211217_47_H5N1_Seg4_HA	A/chicken/Tyumen/47-88V/2021	avian_flu	EPI_ISL_8769021	2021-10-12	Europe	Russian Federation	Tyumen Oblast	Tyumen	Gallus gallus domesticus	NA
 EPI1958001|211217_46_H5N1_Seg4_HA	A/chicken/Tyumen/47-85V/2021	avian_flu	EPI_ISL_8769020	2021-10-12	Europe	Russian Federation	Tyumen Oblast	Tyumen	Gallus gallus domesticus	NA
-EPI1957993|211217_45_H5N1_Seg4_HA	A/chicken/Tyumen/47-85V/2021	avian_flu	EPI_ISL_8769019	2021-10-12	Europe	Russian Federation	Tyumen Oblast	Tyumen	Gallus gallus domesticus	NA
 EPI1957985|211217_44_H5N1_Seg4_HA	A/chicken/Tyumen/47-79V/2021	avian_flu	EPI_ISL_8769018	2021-10-12	Europe	Russian Federation	Tyumen Oblast	Tyumen	Gallus gallus domesticus	NA
 EPI1957977|211217_43_H5N1_Seg4_HA	A/chicken/Tyumen/47-66V/2021	avian_flu	EPI_ISL_8769017	2021-10-11	Europe	Russian Federation	Tyumen Oblast	Tyumen	Gallus gallus domesticus	NA
 EPI1957961|211217_41_H5N1_Seg4_HA	A/chicken/Orenburg/46-2V/2021	avian_flu	EPI_ISL_8769015	2021-10-15	Europe	Russian Federation	Orenburg Oblast	Orenburg	Gallus gallus domesticus	NA
-EPI1957953|211217_40_H5N1_Seg4_HA	A/chicken/Orenburg/46-2V/2021	avian_flu	EPI_ISL_8769014	2021-10-15	Europe	Russian Federation	Orenburg Oblast	Orenburg	Gallus gallus domesticus	NA
 EPI1957945|211217_39_H5N1_Seg4_HA	A/chicken/Orenburg/46-1V/2021	avian_flu	EPI_ISL_8769013	2021-10-15	Europe	Russian Federation	Orenburg Oblast	Orenburg	Gallus gallus domesticus	NA
-EPI1957937|211217_38_H5N1_Seg4_HA	A/chicken/Orenburg/46-1V/2021	avian_flu	EPI_ISL_8769012	2021-10-15	Europe	Russian Federation	Orenburg Oblast	Orenburg	Gallus gallus domesticus	NA
 EPI1957897|211217_33_H5N1_Seg4_HA	A/chicken/Tyumen/33-45V/2021	avian_flu	EPI_ISL_8769007	2021-10-07	Europe	Russian Federation	Tyumen Oblast	Tyumen	Gallus gallus domesticus	NA
 EPI1957888|211217_32_H5N1_Seg4_HA	A/chicken/Saratov/29-6V/2021	avian_flu	EPI_ISL_8769004	2021-09-30	Europe	Russian Federation	Saratov Oblast	Saratov	Gallus gallus domesticus	NA
 EPI1957863|211217_29_H5N1_Seg4_HA	A/chicken/Tyumen/27-42V/2021	avian_flu	EPI_ISL_8768974	2021-10-02	Europe	Russian Federation	Tyumen Oblast	Tyumen	Gallus gallus domesticus	NA
@@ -15381,7 +15313,6 @@ EPI492325|A/goose/Eastern China/223/2008	A/goose/Eastern China/223/2008	avian_fl
 EPI352956|A/Canada goose/England/AV578-8276/2008	A/Canada goose/England/AV578-8276/2008	avian_flu	EPI_ISL_103376	2008-02-01	Europe	United Kingdom	Dorset	NA	Goose	NA
 EPI305547|HA-2841-24	A/Goose/Turkey-Erzurum/09rs2841-24/2006	avian_flu	EPI_ISL_87090	2006-01-07	Asia	Turkey	Erzurum	NA	Goose	NA
 EPI305543|HA-2841-17	A/Goose/Turkey-Agri/09rs2841-17/2006	avian_flu	EPI_ISL_87086	2006-01-06	Asia	Turkey	Agri	NA	Goose	NA
-EPI115465|A/goose/Cambodia/022b/2005	A/goose/Cambodia/022b/2005	avian_flu	EPI_ISL_21083	NA	Asia	Cambodia	NA	NA	Goose	NA
 EPI22759|A/Gs/Thailand/79/2004	A/Gs/Thailand/79/2004	avian_flu	EPI_ISL_4154	NA	Asia	Thailand	NA	NA	Goose	NA
 EPI241729|A/grey lag goose/Denmark/6692/2006	A/grey lag goose/Denmark/6692/2006	avian_flu	EPI_ISL_69731	2006-03-21	Europe	Denmark	Region Syddanmark	Svendborg Kommune	Anser anser	Wild
 EPI669856|A/Black-necked Grebe/Inner Mongolia/Anal swab4/2015_H5N1 HA	A/Black-necked Grebe/Inner Mongolia/Anal swab4/2015 H5N1	avian_flu	EPI_ISL_201010	2015-05-12	Asia	China	Inner Mongolia	NA	Anser indicus	NA
@@ -15454,7 +15385,6 @@ EPI2579967|A/ruddy turnstone/Iceland/2899/2013	A/ruddy turnstone/Iceland/2899/20
 EPI1998430|A/mute_swan/Ireland/037311_22VIR1325-13/2021	A/mute_swan/Ireland/037311_22VIR1325-13/2021	avian_flu	EPI_ISL_11260218	2021-12-22	Europe	Ireland	NA	NA	Other avian	NA
 EPI1949882|A/egret/France/21P013418/2021	A/egret/France/21P013418/2021	avian_flu	EPI_ISL_8377254	2021-12-03	Europe	France	Rhone-Alpes	Departement de l'Ain	Other avian	Wild
 EPI1626247|A/great crested grebe/Sevastopol/11-173/2008	A/great crested grebe/Sevastopol/11-173/2008	avian_flu	EPI_ISL_398110	NA	Europe	Ukraine	Misto Sevastopol'	NA	Other avian	NA
-EPI1180557|A/great crested grebe/Sevastopol/11-173/08	A/great crested grebe/Sevastopol/11-173/2008	avian_flu	EPI_ISL_299865	NA	Europe	Ukraine	Avtonomna Respublika Krym	Sevastopol	Other avian	Wild
 EPI241665|A/peacock/Denmark/60295/2006	A/peacock/Denmark/60295/2006	avian_flu	EPI_ISL_69723	2006-05-16	Europe	Denmark	Region Syddanmark	Kerteminde Kommune	Other avian	Domestic
 EPI241648|A/great crested grebe/Denmark/7498/2006	A/great crested grebe/Denmark/7498/2006	avian_flu	EPI_ISL_69721	2006-04-28	Europe	Denmark	Region Syddanmark	Sonderborg Kommune	Other avian	Wild
 EPI241640|A/buzzard/Denmark/6370/2006	A/buzzard/Denmark/6370/2006	avian_flu	EPI_ISL_69720	2006-03-15	Europe	Denmark	Region Sjaland	Vordingborg Kommune	Other avian	Wild
@@ -15504,7 +15434,6 @@ NA	A/Vietnam/C076H/2012	avian_flu	EPI_ISL_332671	NA	Asia	Vietnam	Hanoi	NA	Human	
 NA	A/Vietnam/VP13-28H/2013	avian_flu	EPI_ISL_332670	NA	Asia	Vietnam	Hanoi	NA	Human	NA
 NA	A/Egypt/MOH-NRC-7305/2014	avian_flu	EPI_ISL_332669	NA	Africa	Egypt	Hanoi	NA	Human	NA
 NA	A/Egypt/MOH-NRC-7271/2014	avian_flu	EPI_ISL_332668	NA	Africa	Egypt	Hanoi	NA	Human	NA
-NA	A/Cambodia/X0207301/2013	avian_flu	EPI_ISL_332667	NA	Asia	Cambodia	Hanoi	NA	Human	NA
 NA	A/Cambodia/X0828324/2013	avian_flu	EPI_ISL_332666	NA	Asia	Cambodia	Hanoi	NA	Human	NA
 NA	A/Cambodia/X0817302/2013	avian_flu	EPI_ISL_332665	NA	Asia	Cambodia	Hanoi	NA	Human	NA
 NA	A/Indonesia/NIHRD-11454/2011	avian_flu	EPI_ISL_332664	NA	Asia	Indonesia	Hanoi	NA	Human	NA
@@ -15517,22 +15446,17 @@ EPI1328380|A/Vietnam/213/2003	A/Vietnam/213/2003	avian_flu	EPI_ISL_332658	NA	Asi
 EPI492524|A/Indonesia/NIHRD13233/2013	A/Indonesia/NIHRD13233/2013	avian_flu	EPI_ISL_151752	2013-09-27	Asia	Indonesia	West Java	NA	Human	NA
 EPI352222|A/Guizhou/1/2012	A/Guizhou/1/2012	avian_flu	EPI_ISL_102993	2012-01-22	Asia	China	Guizhou Province	NA	Human	NA
 EPI244098|R80/05,HA	A/duck/Vietnam/TG24/05	avian_flu	EPI_ISL_70397	2005-06-27	Asia	Vietnam	Vietnam	NA	Human	NA
-EPI123776|A/Vietnam/1196/2004	A/Vietnam/1196/2004	avian_flu	EPI_ISL_21193	NA	Asia	Vietnam	NA	NA	Human	NA
 EPI116533|A/Thailand/Chaiyaphum/622/2004	A/Thailand/Chaiyaphum/622/2004	avian_flu	EPI_ISL_21104	NA	Asia	Thailand	Chaiyaphum	NA	Human	NA
-EPI116503|A/Viet_Nam/1194/2004	A/Viet Nam/1194/2004	avian_flu	EPI_ISL_21100	NA	Asia	Vietnam	NA	NA	Human	NA
 EPI116501|A/Hong_Kong/213/2003	A/Hong Kong/213/2003	avian_flu	EPI_ISL_21099	NA	Asia	China	NA	NA	Human	NA
 EPI116482|A/Prachinburi/6231/2004	A/Prachinburi/6231/2004	avian_flu	EPI_ISL_21097	NA	Asia	Thailand	NA	NA	Human	NA
 NA	A/Viet Nam/1204/2004	avian_flu	EPI_ISL_21088	NA	Asia	Vietnam	NA	NA	Human	NA
 EPI116515|A/Thailand/16/2004	A/Thailand/16/2004	avian_flu	EPI_ISL_21081	NA	Asia	Thailand	NA	NA	Human	NA
 EPI116505|A/Viet_Nam/1203/2004	A/Viet Nam/1203/2004	avian_flu	EPI_ISL_21080	NA	Asia	Vietnam	NA	NA	Human	NA
 NA	A/Thailand/SP83/2004	avian_flu	EPI_ISL_21079	NA	Asia	Thailand	NA	NA	Human	NA
-NA	A/Hong Kong/516/97	avian_flu	EPI_ISL_20934	NA	Asia	Hong Kong (SAR)	NA	NA	Human	NA
 EPI24912|A/Viet_Nam/DN-33/2004	A/Viet Nam/DN-33/2004	avian_flu	EPI_ISL_4513	NA	Asia	Vietnam	NA	NA	Human	NA
 EPI24675|A/Thailand/LFPN-2004/2004	A/Thailand/LFPN-2004/2004	avian_flu	EPI_ISL_4475	NA	Asia	Thailand	NA	NA	Human	NA
 EPI22767|A/Viet_Nam/3062/2004	A/Viet Nam/3062/2004	avian_flu	EPI_ISL_4158	NA	Asia	Vietnam	NA	NA	Human	NA
 EPI22765|A/Viet_Nam/3046/2004	A/Viet Nam/3046/2004	avian_flu	EPI_ISL_4157	NA	Asia	Vietnam	NA	NA	Human	NA
-EPI22763|A/Viet_Nam/1203/2004, EPI123515|A/Viet_Nam/1203/2004, EPI123513|A/Viet_Nam/1203/2004, EPI123511|A/Viet_Nam/1203/2004, EPI123509|A/Viet_Nam/1203/2004, EPI123507|A/Viet_Nam/1203/2004, EPI123505|A/Viet_Nam/1203/2004, EPI123503|A/Viet_Nam/1203/2004, EPI123501|A/Viet_Nam/1203/2004, EPI123499|A/Viet_Nam/1203/2004, EPI123497|A/Viet_Nam/1203/2004, EPI123495|A/Viet_Nam/1203/2004, EPI25595|A/Viet_Nam/1203/2004	A/Viet Nam/1203/2004	avian_flu	EPI_ISL_4156	NA	Asia	Vietnam	NA	NA	Human	NA
-EPI22761|A/Viet_Nam/1194/2004	A/Viet Nam/1194/2004	avian_flu	EPI_ISL_4155	NA	Asia	Vietnam	NA	NA	Human	NA
 EPI3084340|A/Crow/Dhaka/BDADC-440/2019_HA	A/Crow/Dhaka/BDADC-440/2019	avian_flu	EPI_ISL_18945385	2019-01-12	Asia	Bangladesh	Dhaka Division	Dhaka	Avian	NA
 EPI3084339|A/Crow/Dhaka/BDADC-445/2019_HA	A/Crow/Dhaka/BDADC-445/2019	avian_flu	EPI_ISL_18945384	2019-01-14	Asia	Bangladesh	Dhaka Division	Dhaka	Avian	NA
 EPI3084338|A/Crow/Dhaka/BDADC-450/2019_HA	A/Crow/Dhaka/BDADC-450/2019	avian_flu	EPI_ISL_18945383	2019-02-02	Asia	Bangladesh	Dhaka Division	Dhaka	Avian	NA
@@ -15854,7 +15778,6 @@ EPI493519|A/chicken/Egypt/Q1397D/2010	A/chicken/Egypt/Q1397D/2010	avian_flu	EPI_
 EPI500109|A/chicken/Egypt/Q5283C/2012	A/chicken/Egypt/Q5283C/2012	avian_flu	EPI_ISL_151973	2012-05-06	Africa	Egypt	NA	NA	Chicken	NA
 EPI493497|A/chicken/Egypt/S2938D/2011	A/chicken/Egypt/S2938D/2011	avian_flu	EPI_ISL_151972	2011-02-28	Africa	Egypt	NA	NA	Chicken	NA
 EPI493452|A/chicken/Egypt/Q1089E/2010	A/chicken/Egypt/Q1089E/2010	avian_flu	EPI_ISL_151970	2010-01-13	Africa	Egypt	NA	NA	Chicken	NA
-NA	A/chicken/Egypt/M7217B/2013	avian_flu	EPI_ISL_151969	2013-01-31	Africa	Egypt	NA	NA	Chicken	NA
 EPI493430|A/chicken/Egypt/S3280E/2011	A/chicken/Egypt/S3280E/2011	avian_flu	EPI_ISL_151967	2011-05-12	Africa	Egypt	NA	NA	Chicken	NA
 EPI493386|A/chicken/Egypt/Q1112E/2010	A/chicken/Egypt/Q1112E/2010	avian_flu	EPI_ISL_151966	2010-01-27	Africa	Egypt	NA	NA	Chicken	NA
 EPI493321|A/chicken/Egypt/Q1090E/2010	A/chicken/Egypt/Q1090E/2010	avian_flu	EPI_ISL_151963	2010-01-13	Africa	Egypt	NA	NA	Chicken	NA
@@ -15948,11 +15871,7 @@ EPI305542|HA-2841-14	A/Chicken/Turkey-Igdir/09rs2841-14/2006	avian_flu	EPI_ISL_8
 EPI305541|HA-2841-12	A/Chicken/Turkey-Agri/09rs2841-12/2006	avian_flu	EPI_ISL_87084	2006-01-06	Asia	Turkey	Agri	NA	Chicken	NA
 EPI305540|HA-2841-10	A/Chicken/Turkey-Agri/09rs2841-10/2005	avian_flu	EPI_ISL_87083	2005-12-11	Asia	Turkey	Agri	NA	Chicken	NA
 EPI243076|A/chicken/Scotland/59	A/chicken/Scotland/59	avian_flu	EPI_ISL_70100	NA	Europe	United Kingdom	NA	NA	Chicken	NA
-NA	A/chicken/Scotland/59	avian_flu	EPI_ISL_70099	NA	Europe	United Kingdom	NA	NA	Chicken	NA
-EPI243070|A/chicken/Scotland/1959	A/chicken/Scotland/1959	avian_flu	EPI_ISL_70098	NA	Europe	United Kingdom	NA	NA	Chicken	NA
 NA	A/Chicken/Scotland/59	avian_flu	EPI_ISL_69865	NA	Europe	United Kingdom	NA	NA	Chicken	NA
-EPI242232|A/Chicken/Scotland/59	A/Chicken/Scotland/59	avian_flu	EPI_ISL_69864	NA	Europe	United Kingdom	NA	NA	Chicken	NA
-EPI242227|A/chicken/Scotland/1959	A/chicken/Scotland/1959	avian_flu	EPI_ISL_69863	NA	Europe	United Kingdom	NA	NA	Chicken	NA
 EPI242197|A/Chicken/Anhui/M	A/Chicken/Anhui/M	avian_flu	EPI_ISL_69851	NA	Asia	China	NA	NA	Chicken	NA
 NA	A/chicken/Viet Nam/Ncvd8/2003	avian_flu	EPI_ISL_21105	NA	Asia	Vietnam	NA	NA	Chicken	NA
 NA	A/chicken/Cambodia/022LC3b/2005	avian_flu	EPI_ISL_21085	NA	Asia	Cambodia	NA	NA	Chicken	NA
@@ -16052,7 +15971,6 @@ EPI1398270|HA_Niger/17RS32-4	A/duck/Niger/17RS32-4/2016	avian_flu	EPI_ISL_348267
 EPI1398266|HA_Ivory_Coast/17RS804-79	A/duck/Ivory_Coast/17RS804-79/2016	avian_flu	EPI_ISL_348263	2016-12-15	Africa	Cote d'Ivoire	Como? district	NA	Duck	NA
 EPI1398258|HA_Ghana/16VIR4304-21	A/duck/Ghana/16VIR4304-21/2016	avian_flu	EPI_ISL_348255	2016-06-10	Africa	Ghana	Ashanti Region	Atwima Nwabiagya district	Duck	NA
 EPI1322960|A/duck/Bangladesh/AR132-18 D1/2016	A/duck/Bangladesh/AR132-18 D1/2016	avian_flu	EPI_ISL_331846	2016-11-14	Asia	Bangladesh	Dhaka Division	NA	Duck	Domestic
-EPI1009420|A/duck/Sukoharjo/BBVW-1428-9/2012	A/duck/Sukoharjo/BBVW-1428-9/2012	avian_flu	EPI_ISL_266808	NA	Asia	Indonesia	Central Java	NA	Duck	NA
 EPI1009399|A/duck/Klaten/04160386/2016	A/duck/Klaten/04160386/2016	avian_flu	EPI_ISL_266806	2016-03-29	Asia	Indonesia	Central Java	NA	Duck	NA
 EPI1009375|A/duck/Sukoharjo/04160290/2016	A/duck/Sukoharjo/04160290/2016	avian_flu	EPI_ISL_266803	2016-03-03	Asia	Indonesia	Central Java	NA	Duck	NA
 EPI1009318|A/duck/Sidrap/07160336-3/2016	A/duck/Sidrap/07160336-3/2016	avian_flu	EPI_ISL_266795	2016-04-04	Asia	Indonesia	South Sulawesi	NA	Duck	NA
@@ -16084,8 +16002,6 @@ EPI352310|A/duck/India/02CA10/2011	A/duck/India/02CA10/2011	avian_flu	EPI_ISL_10
 EPI352287|A/duck/India/02AF1/2011	A/duck/India/02AF1/2011	avian_flu	EPI_ISL_103033	NA	Asia	India	NA	NA	Duck	NA
 EPI305551|HA-2841-34	A/Duck/Turkey-Aydin/09rs2841-34/2006	avian_flu	EPI_ISL_87094	2006-01-12	Asia	Turkey	Aydin	NA	Duck	NA
 EPI305544|HA-2841-20	A/Duck/Turkey-Igdir/09rs2841-20/2005	avian_flu	EPI_ISL_87087	2005-12-26	Asia	Turkey	Igdir	NA	Duck	NA
-NA	A/duck/Fujian/01/2002	avian_flu	EPI_ISL_70631	NA	Asia	China	NA	NA	Duck	NA
-NA	A/duck/Guangxi/53/2002	avian_flu	EPI_ISL_70630	NA	Asia	China	NA	NA	Duck	NA
 EPI241721|A/tufted duck/Denmark/6431/2006	A/tufted duck/Denmark/6431/2006	avian_flu	EPI_ISL_69730	2006-03-15	Europe	Denmark	Region Syddanmark	AEro	Duck	Wild
 EPI241673|A/tufted duck/Denmark/6540/2006	A/tufted duck/Denmark/6540/2006	avian_flu	EPI_ISL_69724	2006-03-19	Europe	Denmark	Region Sjaland	Vordingborg Kommune	Duck	Wild
 EPI156489|A/Duck/Viet_Nam/NCVD08/2005	A/Duck/Viet Nam/NCVD08/2005	avian_flu	EPI_ISL_21337	NA	Asia	Vietnam	NA	NA	Duck	NA
@@ -16177,7 +16093,6 @@ EPI1888013|A/turkey/Bangladesh/2558/2019 (H5N1)	A/goose/Bangladesh/2558/2019 (H5
 EPI1843642|HA_20VIR8073-4	A/greater_white-fronted_goose/Italy/20VIR8073-4/2020	avian_flu	EPI_ISL_956412	2020-11-23	Europe	Italy	Gorizia	NA	Goose	NA
 EPI841536|Ismailia_1 (HA)	A/goose/Ismailia/1/2014	avian_flu	EPI_ISL_235124	2014-01-18	Africa	Egypt	Ismailia	Abo sweir	Goose	NA
 NA	A/goose/Guiyang/337/2006	avian_flu	EPI_ISL_136430	NA	Asia	China	NA	NA	Goose	NA
-EPI353341|A/Canada goose/Germany/R71/2006	A/Canada goose/Germany/R71/2006	avian_flu	EPI_ISL_103676	NA	Europe	Germany	NA	NA	Goose	NA
 EPI246013|A/goose/Egypt/0946smL-NLQP/2009	A/goose/Egypt/0946smL-NLQP/2009	avian_flu	EPI_ISL_71030	NA	Africa	Egypt	NA	NA	Goose	NA
 EPI246011|A/goose/Egypt/0912smg-NLQP/2009	A/goose/Egypt/0912smg-NLQP/2009	avian_flu	EPI_ISL_71028	NA	Africa	Egypt	NA	NA	Goose	NA
 EPI246009|A/goose/Egypt/09102smf-NLQP/2009	A/goose/Egypt/09102smf-NLQP/2009	avian_flu	EPI_ISL_71026	NA	Africa	Egypt	NA	NA	Goose	NA
@@ -16296,7 +16211,6 @@ EPI2580024|A/environment/Jakarta/BPPVRVIII-344-20/2010	A/environment/Jakarta/BPP
 EPI2580023|A/environment/Jakarta/BPPVRVIII-344-19/2010	A/environment/Jakarta/BPPVRVIII-344-19/2010	avian_flu	EPI_ISL_17733072	NA	Asia	Indonesia	Jakarta	NA	Other environment	NA
 EPI499474|A/environment/Cambodia/E1240W39M4/2013	A/environment/Cambodia/E1240W39M4/2013	avian_flu	EPI_ISL_153022	2013-09-23	Asia	Cambodia	Khett Kampong Cham	NA	Other environment	NA
 EPI497946|A/environment/Cambodia/C1228W39M3/2013	A/environment/Cambodia/C1228W39M3/2013	avian_flu	EPI_ISL_153019	2013-09-24	Asia	Cambodia	Khett Takev	NA	Other environment	NA
-NA	A/environment/Cambodia/C303W9M2/2013	avian_flu	EPI_ISL_153014	2013-02-25	Asia	Cambodia	Krong Phnum Penh	NA	Other environment	NA
 EPI432285|r28HA	r28	avian_flu	EPI_ISL_137378	2010-03-28	Asia	China	NA	NA	Laboratory derived	NA
 EPI432261|r268HA	r268	avian_flu	EPI_ISL_137375	2010-03-28	Asia	China	NA	NA	Laboratory derived	NA
 EPI432253|r2678HA	r2678	avian_flu	EPI_ISL_137374	2010-03-28	Asia	China	NA	NA	Laboratory derived	NA
@@ -16405,7 +16319,6 @@ EPI2580125|A/Egypt/N5561/2014	A/Egypt/N5561/2014	avian_flu	EPI_ISL_17733386	2014
 EPI2580124|A/Egypt/N5560/2014	A/Egypt/N5560/2014	avian_flu	EPI_ISL_17733385	2014-12-15	Africa	Egypt	NA	NA	Human	NA
 EPI497961|A/Cambodia/X1030304/2013	A/Cambodia/X1030304/2013	avian_flu	EPI_ISL_153029	2013-10-25	Asia	Cambodia	Khett Pouthisat	NA	Human	NA
 NA	A/Cambodia/X1014305/2013	avian_flu	EPI_ISL_153024	2013-11-10	Asia	Cambodia	Khett Kampong Thum	NA	Human	NA
-NA	A/Viet Nam/1204/2004	avian_flu	EPI_ISL_136428	NA	Asia	Vietnam	NA	NA	Human	NA
 NA	A/Viet Nam/HN31604/2009	avian_flu	EPI_ISL_136413	NA	Asia	Vietnam	NA	NA	Human	NA
 NA	A/Viet Nam/HN30850/2005	avian_flu	EPI_ISL_136412	NA	Asia	Vietnam	NA	NA	Human	NA
 EPI373023|13	A/Egypt/17692/2010	avian_flu	EPI_ISL_120315	NA	Africa	Egypt	NA	NA	Human	NA
@@ -16703,7 +16616,6 @@ EPI499479|A/chicken/Jiangsu/XZ/2010	A/chicken/Jiangsu/XZ/2010	avian_flu	EPI_ISL_
 EPI499478|A/chicken/China/AH/2012	A/chicken/China/AH/2012	avian_flu	EPI_ISL_153620	2012-09-05	Asia	China	NA	NA	Chicken	NA
 EPI497942|A/chicken/Cambodia/828W25M1/2013	A/chicken/Cambodia/828W25M1/2013	avian_flu	EPI_ISL_153015	2013-06-19	Asia	Cambodia	Krong Phnum Penh	NA	Chicken	Domestic
 NA	A/chicken/Indonesia/NC/2009	avian_flu	EPI_ISL_136424	NA	Asia	Indonesia	NA	NA	Chicken	NA
-NA	A/chicken/Miyazaki/K11/2007	avian_flu	EPI_ISL_136422	NA	Asia	Japan	Miyazaki	NA	Chicken	NA
 NA	A/chicken/Viet Nam/TY101/2007	avian_flu	EPI_ISL_136421	NA	Asia	Vietnam	NA	NA	Chicken	NA
 NA	A/chicken/Indonesia/UT3091/2005	avian_flu	EPI_ISL_136420	NA	Asia	Indonesia	NA	NA	Chicken	NA
 NA	A/chicken/Viet Nam/NCVD5/2003	avian_flu	EPI_ISL_136419	NA	Asia	Vietnam	NA	NA	Chicken	NA
@@ -16761,7 +16673,6 @@ EPI245978|A/chicken/Egypt/088-NLQP/2008	A/chicken/Egypt/088-NLQP/2008	avian_flu	
 EPI46000|A/chicken/Sudan/1784-10/2006	A/chicken/Sudan/1784-10/2006	avian_flu	EPI_ISL_6250	NA	Africa	Sudan	NA	NA	Chicken	NA
 EPI45981|A/chicken/Sudan/1784-7/2006	A/chicken/Sudan/1784-7/2006	avian_flu	EPI_ISL_6249	NA	Africa	Sudan	NA	NA	Chicken	NA
 EPI45962|A/chicken/Nigeria/957-20/2006	A/chicken/Nigeria/957-20/2006	avian_flu	EPI_ISL_6248	NA	Africa	Nigeria	NA	NA	Chicken	NA
-EPI45943|A/chicken/Nigeria/641/2006	A/chicken/Nigeria/641/2006	avian_flu	EPI_ISL_6247	2006-01-17	Africa	Nigeria	NA	NA	Chicken	NA
 EPI41118|A/chicken/Indonesia/CDC24/2005	A/chicken/Indonesia/CDC24/2005	avian_flu	EPI_ISL_5733	2005-10-04	Asia	Indonesia	NA	NA	Chicken	NA
 EPI41099|A/chicken/Indonesia/CDC25/2005	A/chicken/Indonesia/CDC25/2005	avian_flu	EPI_ISL_5732	2005-10-04	Asia	Indonesia	NA	NA	Chicken	NA
 EPI2134101|A/Buff Orpington chicken/South Africa/21050364/2021 (H5N1)	A/Buff Orpington chicken/South Africa/21050364/2021 (H5N1)	avian_flu	EPI_ISL_14620233	2021-05-19	Africa	South Africa	Province of the Western Cape	Hout Bay	Gallus gallus	Domestic
@@ -16978,13 +16889,10 @@ NA	A/goose/China/KUST-ZT-BTY1/2021	avian_flu	EPI_ISL_18718148	2021-12-01	Asia	Ch
 EPI2882860|A/goose/China/KUST-03/2021_HA	A/goose/China/KUST-03/2021	avian_flu	EPI_ISL_18718145	2021-12-01	Asia	China	NA	NA	Goose	NA
 EPI2882859|A/goose/China/KUST-02/2021_HA	A/goose/China/KUST-02/2021	avian_flu	EPI_ISL_18718144	2021-12-01	Asia	China	NA	NA	Goose	NA
 EPI2882293|A/goose/China/KUST-01/2021_HA	A/goose/China/KUST-01/2021	avian_flu	EPI_ISL_18718036	2021-12-01	Asia	China	NA	NA	Goose	NA
-EPI2584568|A/goose/Egypt/135S/2013_HA	A/goose/Egypt/135S/2013	avian_flu	EPI_ISL_17767367	2013-01-17	Africa	Egypt	NA	NA	Goose	NA
 EPI2584473|A/goose/Czech Republic/18520-2/2021_HA	A/goose/Czech Republic/18520-2/2021	avian_flu	EPI_ISL_17767203	2021-09-27	Europe	Czech Republic	NA	NA	Goose	NA
 EPI2584472|A/goose/Czech Republic/18520-1/2021_HA	A/goose/Czech Republic/18520-1/2021	avian_flu	EPI_ISL_17767177	2021-09-27	Europe	Czech Republic	NA	NA	Goose	NA
 EPI2584399|A/goose/Guangdong/1/1996_HA	A/goose/Guangdong/1/1996	avian_flu	EPI_ISL_17767104	1996-01-01	Asia	China	Guangdong Province	NA	Goose	NA
 EPI2584367|A/goose/Bangladesh/BDADAI-2558/2019_HA	A/goose/Bangladesh/BDADAI-2558/2019	avian_flu	EPI_ISL_17767073	2019-11-19	Asia	Bangladesh	NA	NA	Goose	NA
-EPI2580517|A/goose/Czech Republic/18520-2/2021	A/goose/Czech Republic/18520-2/2021	avian_flu	EPI_ISL_17734230	2021-09-27	Europe	Czech Republic	NA	NA	Goose	NA
-EPI2580482|A/goose/Bangladesh/BDADAI-2558/2019	A/goose/Bangladesh/BDADAI-2558/2019	avian_flu	EPI_ISL_17734196	2019-11-19	Asia	Bangladesh	NA	NA	Goose	NA
 EPI2580376|A/goose/Egypt/4/2016	A/goose/Egypt/4/2016	avian_flu	EPI_ISL_17734081	NA	Africa	Egypt	NA	NA	Goose	NA
 EPI2580319|A/goose/Vietnam/HU10-1141/2018	A/goose/Vietnam/HU10-1141/2018	avian_flu	EPI_ISL_17733697	2018-08-28	Asia	Vietnam	NA	NA	Goose	NA
 EPI1925548|A/goose/Netherlands/21037720-001/2021	A/goose/Netherlands/21037720-001/2021	avian_flu	EPI_ISL_6101869	2021-10-28	Europe	Netherlands	Provincie Noord-Holland	NA	Goose	Wild
@@ -17023,7 +16931,6 @@ EPI355443|A/swan/Shanghai/10/2009	A/swan/Shanghai/10/2009	avian_flu	EPI_ISL_1050
 EPI57935|A/cygnus_olor/Italy/808/2006	A/cygnus olor/Italy/808/2006	avian_flu	EPI_ISL_6891	NA	Europe	Italy	Apulia	NA	Swan	NA
 EPI47732|A/swan/Slovenia/760/2006	A/swan/Slovenia/760/2006	avian_flu	EPI_ISL_6414	NA	Europe	Slovenia	NA	NA	Swan	NA
 EPI47200|A/cygnus_olor/Croatia/1/2005	A/cygnus olor/Croatia/1/2005	avian_flu	EPI_ISL_6386	NA	Europe	Croatia	NA	NA	Swan	NA
-EPI47105|A/cygnus_cygnus/Iran/754/2006	A/cygnus cygnus/Iran/754/2006	avian_flu	EPI_ISL_6381	NA	Asia	Iran, Islamic Republic of	NA	NA	Swan	NA
 EPI559910|A/whooper swan/Henan/SMX9/2015	A/whooper swan/Henan/SMX9/2015(H5N1)	avian_flu	EPI_ISL_171186	2015-01-05	Asia	China	Henan Province	NA	Cygnus cygnus	Wild
 EPI559789|A/whooper swan/Henan/SMX4/2015	A/whooper swan/Henan/SMX4/2015(H5N1)	avian_flu	EPI_ISL_171165	2015-01-05	Asia	China	Henan Province	NA	Cygnus cygnus	Wild
 EPI559770|A/whooper swan/Henan/SMX3/2015	A/whooper swan/Henan/SMX3/2015(H5N1)	avian_flu	EPI_ISL_171141	2015-01-04	Asia	China	Henan Province	NA	Cygnus cygnus	Wild
@@ -17031,13 +16938,9 @@ EPI559727|A/whooper swan/Henan/SMX1/2015	A/whooper swan/Henan/SMX1/2015(H5N1)	av
 EPI355250|A/whooper swan/Hamanaka/2011	A/whooper swan/Hamanaka/2011	avian_flu	EPI_ISL_104888	2011-01-30	Asia	Japan	NA	NA	Cygnus cygnus	NA
 EPI340395|A/whooper swan/Hokkaido/3/2011, EPI314194|A/whooper swan/Hokkaido/3/2011	A/whooper swan/Hokkaido/3/2011	avian_flu	EPI_ISL_89172	NA	Asia	Japan	Hokkaido	NA	Cygnus cygnus	NA
 EPI1937671|A/mute_swan/Poland/MB490-L1/2021	A/mute_swan/Poland/MB490-L1/2021	avian_flu	EPI_ISL_6937114	2021-11-08	Europe	Poland	Greater Poland Voivodeship	NA	Cygnus olor	Wild
-EPI47713|A/cygnus_olor/Italy/742/2006	A/cygnus olor/Italy/742/2006	avian_flu	EPI_ISL_6413	2006-02-10	Europe	Italy	NA	NA	Cygnus olor	NA
 EPI2584582|A/turkey/Assiut/CLEVB-AMH2/2014_HA	A/turkey/Assiut/CLEVB-AMH2/2014	avian_flu	EPI_ISL_17767381	2014-06-28	Africa	Egypt	NA	NA	Turkey	NA
 EPI2584566|A/turkey/Egypt/1248CA/2012_HA	A/turkey/Egypt/1248CA/2012	avian_flu	EPI_ISL_17767364	2012-04-04	Africa	Egypt	NA	NA	Turkey	NA
-EPI2584531|A/turkey/Egypt/1318SL/2013_HA	A/turkey/Egypt/1318SL/2013	avian_flu	EPI_ISL_17767331	2013-05-07	Africa	Egypt	Sohag	NA	Turkey	NA
-EPI2584517|A/turkey/Egypt/137/2013_HA	A/turkey/Egypt/137/2013	avian_flu	EPI_ISL_17767317	2013-03-03	Africa	Egypt	New Valley	NA	Turkey	NA
 EPI2584503|A/turkey/Egypt/134S/2013_HA	A/turkey/Egypt/134S/2013	avian_flu	EPI_ISL_17767303	2013-01-15	Africa	Egypt	Giza	NA	Turkey	NA
-EPI2584485|A/turkey/Egypt/13175F/2013_HA	A/turkey/Egypt/13175F/2013	avian_flu	EPI_ISL_17767285	2013-02-28	Africa	Egypt	Cairo	NA	Turkey	NA
 EPI2584369|A/Turkey/Bangladesh/BDADAI-2184/2019_HA	A/Turkey/Bangladesh/BDADAI-2184/2019	avian_flu	EPI_ISL_17767075	2019-06-12	Asia	Bangladesh	NA	NA	Turkey	NA
 EPI2580481|A/turkey/Bangladesh/BDADAI-2184/2019	A/turkey/Bangladesh/BDADAI-2184/2019	avian_flu	EPI_ISL_17734195	2019-06-12	Asia	Bangladesh	NA	NA	Turkey	NA
 EPI2562617|A/turkey/Italy/21VIR9520-3/2021	A/turkey/Italy/21VIR9520-3/2021	avian_flu	EPI_ISL_17684608	2021-11-14	Europe	Italy	Veneto	Province of Verona	Turkey	NA
@@ -17065,7 +16968,6 @@ NA	A/tree sparrow/Ratchaburi/VSMU-16-RBR/2005	avian_flu	EPI_ISL_89187	NA	Asia	Th
 EPI314320|A/pigeon/Thailand/VSMU-7-NPT/2004	A/pigeon/Thailand/VSMU-7-NPT/2004	avian_flu	EPI_ISL_89184	NA	Asia	Thailand	NA	NA	Other avian	NA
 EPI162616|#162616	A/pigeon/Crimea/0624/2005 (H5N1)	avian_flu	EPI_ISL_23498	2005-12-21	Europe	Ukraine	Avtonomna Respublika Krym	NA	Other avian	NA
 EPI47751|A/quail/Viet_Nam/15/2005	A/quail/Viet Nam/15/2005	avian_flu	EPI_ISL_6415	NA	Asia	Vietnam	NA	NA	Other avian	NA
-EPI2584410|A/swine/Guangxi/592/2011_HA	A/swine/Guangxi/592/2011	avian_flu	EPI_ISL_17767115	2011-02-27	Asia	China	Guangxi Zhuang Autonomous Region	NA	Swine	NA
 NA	A/swine/Guangxi/ns592/2011	avian_flu	EPI_ISL_138188	NA	Asia	China	NA	NA	Swine	NA
 EPI2584702|A/environment/Kota Bekasi/0813129-003/2013_HA	A/environment/Kota Bekasi/0813129-003/2013	avian_flu	EPI_ISL_17767760	2013-11-01	Asia	Indonesia	NA	NA	Environment	NA
 EPI2584700|A/environment/Jakarta Utara/081489-008/2013_HA	A/environment/Jakarta Utara/081489-008/2013	avian_flu	EPI_ISL_17767758	2013-11-01	Asia	Indonesia	NA	NA	Environment	NA
@@ -17106,7 +17008,6 @@ EPI2584634|A/environment/East Jakarta/BPPVRVIII-492-CM/2011_HA	A/environment/Eas
 EPI2584633|A/environment/East Jakarta/BPPVRVIII-447-AU/2011_HA	A/environment/East Jakarta/BPPVRVIII-447-AU/2011	avian_flu	EPI_ISL_17767691	2011-09-01	Asia	Indonesia	NA	NA	Environment	NA
 EPI2584632|A/environment/East Jakarta/BPPVRVIII-413-AD/2011_HA	A/environment/East Jakarta/BPPVRVIII-413-AD/2011	avian_flu	EPI_ISL_17767690	2011-09-01	Asia	Indonesia	NA	NA	Environment	NA
 EPI2584631|A/environment/East Jakarta/BPPVRVIII-392-3/2011_HA	A/environment/East Jakarta/BPPVRVIII-392-3/2011	avian_flu	EPI_ISL_17767689	2011-09-01	Asia	Indonesia	NA	NA	Environment	NA
-EPI2584357|A/environment/Bangladesh/14VIR1121-28/2013_HA	A/environment/Bangladesh/14VIR1121-28/2013	avian_flu	EPI_ISL_17767063	2013-01-01	Asia	Bangladesh	NA	NA	Environment	NA
 EPI749465|A/Environment/Hunan/18478/2014-HA	A/Environment/Hunan/18478/2014	avian_flu	EPI_ISL_219776	2014-03-11	Asia	China	Hunan	NA	Environment	NA
 EPI749457|A/Environment/Chongqing/28922/2014-HA	A/Environment/Chongqing/28922/2014	avian_flu	EPI_ISL_219775	2014-04-17	Asia	China	Chongqing	NA	Environment	NA
 EPI749449|A/Environment/Chongqing/28959/2014-HA	A/Environment/Chongqing/28959/2014	avian_flu	EPI_ISL_219774	2014-03-17	Asia	China	Chongqing	NA	Environment	NA
@@ -17184,19 +17085,6 @@ EPI432293|r3HA	r3	avian_flu	EPI_ISL_137379	2010-04-03	Asia	China	NA	NA	Laborator
 EPI432277|r278HA	r278	avian_flu	EPI_ISL_137377	2010-03-28	Asia	China	NA	NA	Laboratory derived	NA
 EPI432269|r27HA	r27	avian_flu	EPI_ISL_137376	2010-03-28	Asia	China	NA	NA	Laboratory derived	NA
 EPI2145147|A/wild waterbird/Queensland/P17-14428-30/2017	A/wild waterbird/Queensland/P17-14428-30/2017	avian_flu	EPI_ISL_14769260	2017-06-12	Oceania	Australia	Queensland	NA	Host	NA
-EPI2584547|A/Egypt/N5565/2014_HA	A/Egypt/N5565/2014	avian_flu	EPI_ISL_17767347	2014-12-24	Africa	Egypt	NA	NA	Human	NA
-EPI2584546|A/Egypt/N5564/2014_HA	A/Egypt/N5564/2014	avian_flu	EPI_ISL_17767346	2014-12-26	Africa	Egypt	NA	NA	Human	NA
-EPI2584545|A/Egypt/N5563/2014_HA	A/Egypt/N5563/2014	avian_flu	EPI_ISL_17767345	2014-12-23	Africa	Egypt	NA	NA	Human	NA
-EPI2584544|A/Egypt/N5561/2014_HA	A/Egypt/N5561/2014	avian_flu	EPI_ISL_17767344	2014-12-14	Africa	Egypt	NA	NA	Human	NA
-EPI2584543|A/Egypt/N5560/2014_HA	A/Egypt/N5560/2014	avian_flu	EPI_ISL_17767343	2014-12-15	Africa	Egypt	NA	NA	Human	NA
-EPI2584542|A/Egypt/N0002/2015_HA	A/Egypt/N0002/2015	avian_flu	EPI_ISL_17767342	2015-01-01	Africa	Egypt	NA	NA	Human	NA
-EPI2584541|A/Egypt/N0001/2015_HA	A/Egypt/N0001/2015	avian_flu	EPI_ISL_17767341	2015-01-01	Africa	Egypt	NA	NA	Human	NA
-EPI2584495|A/Egypt/N5566/2014_HA	A/Egypt/N5566/2014	avian_flu	EPI_ISL_17767295	2014-12-26	Africa	Egypt	Giza	NA	Human	NA
-EPI2584491|A/Egypt/N01754/2014_HA	A/Egypt/N01754/2014	avian_flu	EPI_ISL_17767291	2014-03-07	Africa	Egypt	Dakahlia	NA	Human	NA
-EPI2584482|A/Egypt/N0005/2015_HA	A/Egypt/N0005/2015	avian_flu	EPI_ISL_17767282	2015-01-07	Africa	Egypt	Cairo	NA	Human	NA
-EPI2584477|A/Egypt/N01753/2014_HA	A/Egypt/N01753/2014	avian_flu	EPI_ISL_17767277	2014-03-06	Africa	Egypt	Beheira	NA	Human	NA
-EPI2584476|A/Egypt/N0004/2015_HA	A/Egypt/N0004/2015	avian_flu	EPI_ISL_17767276	2015-01-05	Africa	Egypt	Aswan	NA	Human	NA
-EPI2584394|A/Cambodia/X0125302/2013_HA	A/Cambodia/X0125302/2013	avian_flu	EPI_ISL_17767099	2013-01-25	Asia	Cambodia	NA	NA	Human	NA
 EPI1990182|06S423	A/Vietnam/1204/2004	avian_flu	EPI_ISL_10656750	2006-06-26	Asia	Vietnam	NA	NA	Human	NA
 EPI1990181|06S421	A/Vietnam/1203/2004	avian_flu	EPI_ISL_10656749	2006-06-14	Asia	Vietnam	NA	NA	Human	NA
 EPI1990126|06S753	A/Turkey/Langkat/BPPV1/2005	avian_flu	EPI_ISL_10656718	NA	Asia	Indonesia	North Sumatra	Medan	Human	NA
@@ -17211,8 +17099,6 @@ NA	A/Egypt/MOH-NRC-8434/2014	avian_flu	EPI_ISL_252875	2014-12-27	Africa	Egypt	NA
 EPI942317|A/Cambodia/Y0203301/2014	A/Cambodia/Y0203301/2014	avian_flu	EPI_ISL_252859	2014-01-30	Asia	Cambodia	Khett Kampong Thum	NA	Human	NA
 EPI500771|A/Alberta/01/2014	A/Alberta/01/2014	avian_flu	EPI_ISL_154130	2014-01-03	North America	Canada	Alberta	NA	Human	NA
 NA	A/Vietnam/hn30408/2005	avian_flu	EPI_ISL_138227	NA	Asia	Vietnam	NA	NA	Human	NA
-NA	A/Shenzhen/1/2011	avian_flu	EPI_ISL_138190	NA	Asia	China	NA	NA	Human	NA
-EPI376537|A/Indonesia/5/2005	A/Indonesia/5/2005	avian_flu	EPI_ISL_121541	NA	Asia	Indonesia	NA	NA	Human	NA
 EPI375432|A/Hong Kong/5923/2012	A/Hong Kong/5923/2012	avian_flu	EPI_ISL_121190	2012-05-28	Asia	Hong Kong (SAR)	NA	NA	Human	NA
 EPI55776|A/Indonesia/CDC1047S/2007	A/Indonesia/CDC1047S/2007	avian_flu	EPI_ISL_6802	2007-01-12	Asia	Indonesia	NA	NA	Human	NA
 EPI55757|A/Indonesia/CDC1047/2007	A/Indonesia/CDC1047/2007	avian_flu	EPI_ISL_6801	2007-01-12	Asia	Indonesia	NA	NA	Human	NA
@@ -17244,13 +17130,7 @@ EPI2584747|A/duck/Japan/AQ-HE29-79/2017(H5N1)_HA	A/duck/Japan/AQ-HE29-79/2017(H5
 EPI2584645|A/quail/Pekalongan/BBVW-1769-11/2012_HA	A/quail/Pekalongan/BBVW-1769-11/2012	avian_flu	EPI_ISL_17767703	2012-11-01	Asia	Indonesia	NA	NA	Avian	NA
 EPI2584627|A/bird/Kulon Progo/BBVW-946-06/2011_HA	A/bird/Kulon Progo/BBVW-946-06/2011	avian_flu	EPI_ISL_17767685	2011-06-01	Asia	Indonesia	NA	NA	Avian	NA
 EPI2584626|A/quail/Blitar/BBVW-790-05/2011_HA	A/quail/Blitar/BBVW-790-05/2011	avian_flu	EPI_ISL_17767684	2011-05-01	Asia	Indonesia	NA	NA	Avian	NA
-EPI2584524|A/chicken/Egypt/CLEVB-AMH7/2014_HA	A/chicken/Egypt/CLEVB-AMH7/2014	avian_flu	EPI_ISL_17767325	2014-08-10	Africa	Egypt	Qalyubia	NA	Avian	NA
-EPI2584523|A/chicken/Egypt/CLEVB-AMH5/2014_HA	A/chicken/Egypt/CLEVB-AMH5/2014	avian_flu	EPI_ISL_17767323	2014-04-20	Africa	Egypt	Qalyubia	NA	Avian	NA
-EPI2584521|A/chicken/Egypt/CLEVB-AMH4/2014_HA	A/chicken/Egypt/CLEVB-AMH4/2014	avian_flu	EPI_ISL_17767322	2014-04-10	Africa	Egypt	Qalyubia	NA	Avian	NA
-EPI2584520|A/chicken/Egypt/CLEVB-AMH1/2014_HA	A/chicken/Egypt/CLEVB-AMH1/2014	avian_flu	EPI_ISL_17767320	2014-06-15	Africa	Egypt	Qalyubia	NA	Avian	NA
 EPI2584507|A/chicken/Egypt/VRLCU157-12/2013_HA	A/chicken/Egypt/VRLCU157-12/2013	avian_flu	EPI_ISL_17767307	2013-12-25	Africa	Egypt	Giza	NA	Avian	NA
-EPI2584506|A/chicken/Egypt/CLEVB-AMH10/2014_HA	A/chicken/Egypt/CLEVB-AMH10/2014	avian_flu	EPI_ISL_17767306	2014-07-18	Africa	Egypt	Giza	NA	Avian	NA
-EPI2584486|A/quail/Egypt/14102TCP/2014_HA	A/quail/Egypt/14102TCP/2014	avian_flu	EPI_ISL_17767286	2014-09-19	Africa	Egypt	Cairo	NA	Avian	NA
 EPI2584461|A/common pochard/Shanxi/16B/2015_HA	A/common pochard/Shanxi/16B/2015	avian_flu	EPI_ISL_17767167	2015-01-06	Asia	China	Shanxi Province	NA	Avian	NA
 EPI2584455|A/common cormorant/Qinghai/8/2008_HA	A/common cormorant/Qinghai/8/2008	avian_flu	EPI_ISL_17767161	2008-07-16	Asia	China	Qinghai Province	NA	Avian	NA
 EPI2584453|A/common cormorant/Qinghai/12/2008_HA	A/common cormorant/Qinghai/12/2008	avian_flu	EPI_ISL_17767160	2008-08-23	Asia	China	Qinghai Province	NA	Avian	NA
@@ -17258,22 +17138,14 @@ EPI2584452|A/common cormorant/Qinghai/10/2007_HA	A/common cormorant/Qinghai/10/2
 EPI2584450|A/common cormorant/Qinghai/10/2006_HA	A/common cormorant/Qinghai/10/2006	avian_flu	EPI_ISL_17767156	2006-07-26	Asia	China	Qinghai Province	NA	Avian	NA
 EPI2584448|A/black-neck crane/Qinghai/7/2006_HA	A/black-neck crane/Qinghai/7/2006	avian_flu	EPI_ISL_17767155	2006-07-15	Asia	China	Qinghai Province	NA	Avian	NA
 EPI2584447|A/bar-headed goose/Qinghai/11/2007_HA	A/bar-headed goose/Qinghai/11/2007	avian_flu	EPI_ISL_17767153	2007-08-23	Asia	China	Qinghai Province	NA	Avian	NA
-EPI2584446|A/common teal/Shanghai/PD1108-8/2013_HA	A/common teal/Shanghai/PD1108-8/2013	avian_flu	EPI_ISL_17767152	2013-11-08	Asia	China	Shanghai Municipality	NA	Avian	NA
 EPI2584444|A/common teal/Shanghai/PD1108-4/2013_HA	A/common teal/Shanghai/PD1108-4/2013	avian_flu	EPI_ISL_17767151	2013-11-08	Asia	China	Shanghai Municipality	NA	Avian	NA
 EPI2584443|A/common cormorant/Qinghai/9/2008_HA	A/common cormorant/Qinghai/9/2008	avian_flu	EPI_ISL_17767149	2008-07-16	Asia	China	Qinghai Province	NA	Avian	NA
 EPI2584440|A/common cormorant/Qinghai/9/2007_HA	A/common cormorant/Qinghai/9/2007	avian_flu	EPI_ISL_17767146	2007-07-15	Asia	China	Qinghai Province	NA	Avian	NA
-EPI2584437|A/wild bird/Jiangxi/P410/2015_HA	A/wild bird/Jiangxi/P410/2015	avian_flu	EPI_ISL_17767142	2015-01-07	Asia	China	Jiangxi Province	NA	Avian	NA
-EPI2584432|A/wild bird/Jiangxi/P126/2015_HA	A/wild bird/Jiangxi/P126/2015	avian_flu	EPI_ISL_17767137	2015-01-07	Asia	China	Jiangxi Province	NA	Avian	NA
-EPI2584411|A/common pochard/Henan/09L/2015_HA	A/common pochard/Henan/09L/2015	avian_flu	EPI_ISL_17767116	2015-01-06	Asia	China	Henan Province	NA	Avian	NA
 EPI2584409|A/quail/Guangxi/13/2002_HA	A/quail/Guangxi/13/2002	avian_flu	EPI_ISL_17767114	2002-07-01	Asia	China	Guangxi Zhuang Autonomous Region	NA	Avian	NA
 EPI2584408|A/quail/Guangxi/12/2002_HA	A/quail/Guangxi/12/2002	avian_flu	EPI_ISL_17767113	2002-07-01	Asia	China	Guangxi Zhuang Autonomous Region	NA	Avian	NA
 EPI2584407|A/quail/Guangxi/11/2002_HA	A/quail/Guangxi/11/2002	avian_flu	EPI_ISL_17767112	2002-07-01	Asia	China	Guangxi Zhuang Autonomous Region	NA	Avian	NA
-EPI2584385|A/quail/Bangladesh/22125/2014_HA	A/quail/Bangladesh/22125/2014	avian_flu	EPI_ISL_17767090	2014-03-18	Asia	Bangladesh	NA	NA	Avian	NA
-EPI2584384|A/quail/Bangladesh/22121/2014_HA	A/quail/Bangladesh/22121/2014	avian_flu	EPI_ISL_17767089	2014-03-18	Asia	Bangladesh	NA	NA	Avian	NA
-EPI2584358|A/avian/Bangladesh/14VIR2665-1/2013_HA	A/avian/Bangladesh/14VIR2665-1/2013	avian_flu	EPI_ISL_17767064	2013-06-10	Asia	Bangladesh	NA	NA	Avian	NA
 EPI2053431|A/avian/Burkina_Faso/21VIR11911-3/2021_HA	A/avian/Burkina_Faso/21VIR11911-3/2021	avian_flu	EPI_ISL_13048382	2021-12-07	Africa	Burkina Faso	Gomboussougou	NA	Avian	NA
 EPI2053423|A/avian/Burkina_Faso/21VIR11911-1/2021_HA	A/avian/Burkina_Faso/21VIR11911-1/2021	avian_flu	EPI_ISL_13048381	2021-12-08	Africa	Burkina Faso	Bonyollo	NA	Avian	NA
-NA	A/avian/Burkina_Faso/21VIR11911-1/2021	avian_flu	EPI_ISL_13048328	2021-12-08	Africa	Burkina Faso	Central-Western Region (Bonyollo)	NA	Avian	Domestic
 EPI2040950|08S1726	A/Muscovy Duck/Vietnam/453B/2004	avian_flu	EPI_ISL_10656590	2006-05-15	Asia	Vietnam	NA	NA	Avian	NA
 EPI1989809|06S304	A/Duck/Vietnam/949A/2004	avian_flu	EPI_ISL_10656512	NA	Asia	Vietnam	NA	NA	Avian	NA
 EPI1989806|06S299	A/Duck/Vietnam/942A/2004	avian_flu	EPI_ISL_10656511	2005-05-12	Asia	Vietnam	NA	NA	Avian	NA
@@ -17282,7 +17154,6 @@ EPI1989801|06S768	A/Duck/Pali/BBVW/1358/2005	avian_flu	EPI_ISL_10656509	NA	Asia	
 EPI1989796|06S769	A/Duck/Madiun/BBVW/1358/2005	avian_flu	EPI_ISL_10656506	NA	Asia	Indonesia	Central Java	Wates	Avian	NA
 EPI1989793|06S748	A/Duck/Indramayu/BBVW/109/2006	avian_flu	EPI_ISL_10656505	NA	Asia	Indonesia	Central Java	Wates	Avian	NA
 NA	A/Duck/Gianya/BPPV1/2005	avian_flu	EPI_ISL_10656504	NA	Asia	Indonesia	Bali	NA	Avian	NA
-EPI1989783|06S771	A/Duck/Bufeleng/BPPV1/2005	avian_flu	EPI_ISL_10656503	NA	Asia	Indonesia	Bali	NA	Avian	NA
 EPI1989752|06S746	A/Chicken/Way Kanan/BPPV-III/2006	avian_flu	EPI_ISL_10656484	2005-03-04	Asia	Indonesia	North Sumatra	Lampung	Avian	NA
 NA	A/Chicken/Vietnam/949B/2004	avian_flu	EPI_ISL_10656483	2006-06-30	Asia	Vietnam	NA	NA	Avian	NA
 NA	A/Chicken/Vietnam/942A/2004	avian_flu	EPI_ISL_10656482	2006-06-14	Asia	Vietnam	NA	NA	Avian	NA
@@ -17325,7 +17196,6 @@ NA	A/Chicken/Cambodia/2/2004	avian_flu	EPI_ISL_10656446	2005-09-23	Asia	Cambodia
 NA	A/Chicken/Cambodia/1A/2004	avian_flu	EPI_ISL_10656445	NA	Asia	Cambodia	NA	NA	Avian	NA
 EPI1989644|06S747	A/Chicken/Bandar Lampung/BBPPV1-III/2006	avian_flu	EPI_ISL_10656444	NA	Asia	Indonesia	Lampung	NA	Avian	NA
 EPI1989636|06S758	A/Chicken/Agam/BPPV1/2005	avian_flu	EPI_ISL_10656443	NA	Asia	Indonesia	West Sumatra	Bukillinggi	Avian	NA
-EPI1989407|05S582	A/Quail/Vietnam/826/2004	avian_flu	EPI_ISL_10656185	2004-10-09	Asia	Vietnam	NA	NA	Avian	NA
 EPI1989355|05S295	A/Duck/Vietnam/NCVD08/2005	avian_flu	EPI_ISL_10656159	2005-02-27	Asia	Vietnam	NA	NA	Avian	NA
 EPI1989347|05S294	A/Duck/Vietnam/NCVD07/2005	avian_flu	EPI_ISL_10656158	2005-02-27	Asia	Vietnam	NA	NA	Avian	NA
 EPI1989345|05S293	A/Duck/Vietnam/NCVD06/2005	avian_flu	EPI_ISL_10656157	2005-03-10	Asia	Vietnam	NA	NA	Avian	NA
@@ -17355,20 +17225,13 @@ EPI681276|A/pigeon/Zhejiang/112089/2014	A/pigeon/Zhejiang/112089/2014	avian_flu	
 EPI681275|A/pigeon/Zhejiang/727097/2014	A/pigeon/Zhejiang/727097/2014	avian_flu	EPI_ISL_203754	2014-07-27	Asia	China	NA	NA	Avian	NA
 EPI435659|A/barnswallow/Hong Kong/1161/2010	A/barnswallow/Hong Kong/1161/2010	avian_flu	EPI_ISL_137877	NA	Asia	China	NA	NA	Avian	NA
 NA	A/wild bird/Korea/SNU50-5/2009	avian_flu	EPI_ISL_137472	2009-11-27	Asia	Korea, Republic of	NA	NA	Avian	Wild
-EPI2584777|A/chicken/Nepal/08TI96/2013_HA	A/chicken/Nepal/08TI96/2013	avian_flu	EPI_ISL_17767835	2013-08-25	Asia	Nepal	NA	NA	Chicken	NA
 EPI2584776|A/chicken/Nepal/08TI87/2013_HA	A/chicken/Nepal/08TI87/2013	avian_flu	EPI_ISL_17767834	2013-08-25	Asia	Nepal	NA	NA	Chicken	NA
-EPI2584775|A/chicken/Nepal/08TI82/2013_HA	A/chicken/Nepal/08TI82/2013	avian_flu	EPI_ISL_17767833	2013-08-25	Asia	Nepal	NA	NA	Chicken	NA
-EPI2584774|A/chicken/Nepal/08TI78/2013_HA	A/chicken/Nepal/08TI78/2013	avian_flu	EPI_ISL_17767832	2013-08-25	Asia	Nepal	NA	NA	Chicken	NA
-EPI2584773|A/chicken/Nepal/08TI76/2013_HA	A/chicken/Nepal/08TI76/2013	avian_flu	EPI_ISL_17767831	2013-08-25	Asia	Nepal	NA	NA	Chicken	NA
-EPI2584772|A/chicken/Nepal/08TI63/2013_HA	A/chicken/Nepal/08TI63/2013	avian_flu	EPI_ISL_17767830	2013-08-25	Asia	Nepal	NA	NA	Chicken	NA
-EPI2584748|A/chicken/Libya/14VIR2749-16/2014_HA	A/chicken/Libya/14VIR2749-16/2014	avian_flu	EPI_ISL_17767806	2014-01-01	Africa	Libyan Arab Jamahiriya	NA	NA	Chicken	NA
 EPI2584705|A/chicken/Tanggamus/031711076-65_HA/2017_HA	A/chicken/Tanggamus/031711076-65_HA/2017	avian_flu	EPI_ISL_17767763	2017-11-15	Asia	Indonesia	NA	NA	Chicken	NA
 EPI2584703|A/chicken/Mimika/0514574/2014_HA	A/chicken/Mimika/0514574/2014	avian_flu	EPI_ISL_17767761	2014-05-01	Asia	Indonesia	NA	NA	Chicken	NA
 EPI2584684|A/chicken/Minahasa/BBVM 620(2)/2013_HA	A/chicken/Minahasa/BBVM 620(2)/2013	avian_flu	EPI_ISL_17767742	2013-08-01	Asia	Indonesia	NA	NA	Chicken	NA
 EPI2584673|A/chicken/Kulon Progo/BBVW 801-05/2013_HA	A/chicken/Kulon Progo/BBVW 801-05/2013	avian_flu	EPI_ISL_17767731	2013-05-01	Asia	Indonesia	NA	NA	Chicken	NA
 EPI2584671|A/chicken/Blitar/BBVW 538-04/2013_HA	A/chicken/Blitar/BBVW 538-04/2013	avian_flu	EPI_ISL_17767729	2013-04-01	Asia	Indonesia	NA	NA	Chicken	NA
 EPI2584663|A/chicken/Tulungagung/BBVW 414-03/2013_HA	A/chicken/Tulungagung/BBVW 414-03/2013	avian_flu	EPI_ISL_17767721	2013-03-01	Asia	Indonesia	NA	NA	Chicken	NA
-EPI2584649|A/chicken/West Sulawesi/Polman-1018/2012_HA	A/chicken/West Sulawesi/Polman-1018/2012	avian_flu	EPI_ISL_17767707	2012-12-01	Asia	Indonesia	NA	NA	Chicken	NA
 EPI2584648|A/chicken/Barru/BBVM 41-13/2013_HA	A/chicken/Barru/BBVM 41-13/2013	avian_flu	EPI_ISL_17767706	2013-01-01	Asia	Indonesia	NA	NA	Chicken	NA
 EPI2584647|A/chicken/Sleman/BBVW-1908-12/2012_HA	A/chicken/Sleman/BBVW-1908-12/2012	avian_flu	EPI_ISL_17767705	2012-12-01	Asia	Indonesia	NA	NA	Chicken	NA
 EPI2584638|A/chicken/Karimun/BPPVII 719-11/2012_HA	A/chicken/Karimun/BPPVII 719-11/2012	avian_flu	EPI_ISL_17767696	2012-11-01	Asia	Indonesia	NA	NA	Chicken	NA
@@ -17383,53 +17246,24 @@ EPI2584624|A/chicken/Tabanan/BBVD-0212-4/2011_HA	A/chicken/Tabanan/BBVD-0212-4/2
 EPI2584623|A/chicken/Karangasem/BBVD-0209-4/2011_HA	A/chicken/Karangasem/BBVD-0209-4/2011	avian_flu	EPI_ISL_17767681	2011-04-01	Asia	Indonesia	NA	NA	Chicken	NA
 EPI2584622|A/chicken/Buleleng/BBVD-0224B-4/2011_HA	A/chicken/Buleleng/BBVD-0224B-4/2011	avian_flu	EPI_ISL_17767680	2011-04-01	Asia	Indonesia	NA	NA	Chicken	NA
 EPI2584584|A/chicken/Egypt/CL69/2013_HA	A/chicken/Egypt/CL69/2013	avian_flu	EPI_ISL_17767383	2013-04-10	Africa	Egypt	NA	NA	Chicken	NA
-EPI2584583|A/chicken/Egypt/2010_HA	A/chicken/Egypt/2010	avian_flu	EPI_ISL_17767382	2010-12-14	Africa	Egypt	NA	NA	Chicken	NA
 EPI2584577|A/chicken/Egypt/CAI42/2009_HA	A/chicken/Egypt/CAI42/2009	avian_flu	EPI_ISL_17767376	2009-05-25	Africa	Egypt	NA	NA	Chicken	NA
 EPI2584576|A/chicken/Egypt/CAI34/2010_HA	A/chicken/Egypt/CAI34/2010	avian_flu	EPI_ISL_17767375	2010-04-21	Africa	Egypt	NA	NA	Chicken	NA
 EPI2584575|A/chicken/Egypt/S75/2015_HA	A/chicken/Egypt/S75/2015	avian_flu	EPI_ISL_17767373	2015-01-01	Africa	Egypt	NA	NA	Chicken	NA
 EPI2584573|A/chicken/Egypt/ME1010-RG/2016_HA	A/chicken/Egypt/ME1010-RG/2016	avian_flu	EPI_ISL_17767372	2016-01-01	Africa	Egypt	NA	NA	Chicken	NA
 EPI2584569|A/chicken/Egypt/1427AF/2014_HA	A/chicken/Egypt/1427AF/2014	avian_flu	EPI_ISL_17767368	2014-09-03	Africa	Egypt	NA	NA	Chicken	NA
-EPI2584553|A/chicken/Egypt/1366S/2013_HA	A/chicken/Egypt/1366S/2013	avian_flu	EPI_ISL_17767353	2013-04-27	Africa	Egypt	NA	NA	Chicken	NA
-EPI2584552|A/chicken/Egypt/134AD/2013_HA	A/chicken/Egypt/134AD/2013	avian_flu	EPI_ISL_17767352	2013-01-30	Africa	Egypt	NA	NA	Chicken	NA
 EPI2584551|A/chicken/Egypt/1273CA/2012_HA	A/chicken/Egypt/1273CA/2012	avian_flu	EPI_ISL_17767351	2012-04-12	Africa	Egypt	NA	NA	Chicken	NA
 EPI2584550|A/chicken/Egypt/12257CA/2012_HA	A/chicken/Egypt/12257CA/2012	avian_flu	EPI_ISL_17767350	2012-05-30	Africa	Egypt	NA	NA	Chicken	NA
-EPI2584549|A/chicken/Egypt/13639V/2013_HA	A/chicken/Egypt/13639V/2013	avian_flu	EPI_ISL_17767349	2013-04-16	Africa	Egypt	NA	NA	Chicken	NA
 EPI2584548|A/chicken/Egypt/137FL/2013_HA	A/chicken/Egypt/137FL/2013	avian_flu	EPI_ISL_17767348	2013-01-14	Africa	Egypt	NA	NA	Chicken	NA
 EPI2584530|A/chicken/Egypt/125CAL/2012_HA	A/chicken/Egypt/125CAL/2012	avian_flu	EPI_ISL_17767330	2012-04-04	Africa	Egypt	Sohag	NA	Chicken	NA
 EPI2584528|A/chicken/Egypt/1213CAL/2012_HA	A/chicken/Egypt/1213CAL/2012	avian_flu	EPI_ISL_17767328	2012-04-24	Africa	Egypt	Sohag	NA	Chicken	NA
 EPI2584526|A/chicken/Egypt/101/2011_HA	A/chicken/Egypt/101/2011	avian_flu	EPI_ISL_17767326	2011-02-01	Africa	Egypt	Sharqia	NA	Chicken	NA
-EPI2584519|A/chicken/Egypt/Q7630D/2013_HA	A/chicken/Egypt/Q7630D/2013	avian_flu	EPI_ISL_17767318	2013-04-08	Africa	Egypt	Qalyubia	NA	Chicken	NA
-EPI2584512|A/chicken/Egypt/14VIR784-12-1357S/2013_HA	A/chicken/Egypt/14VIR784-12-1357S/2013	avian_flu	EPI_ISL_17767313	2013-01-01	Africa	Egypt	NA	NA	Chicken	NA
-EPI2584513|A/chicken/Egypt/1352S/2013_HA	A/chicken/Egypt/1352S/2013	avian_flu	EPI_ISL_17767312	2013-03-07	Africa	Egypt	New Valley	NA	Chicken	NA
-EPI2584510|A/chicken/Egypt/14VIR784-10-136A/2013_HA	A/chicken/Egypt/14VIR784-10-136A/2013	avian_flu	EPI_ISL_17767311	2013-01-01	Africa	Egypt	NA	NA	Chicken	NA
-EPI2584511|A/chicken/Egypt/1335S/2013_HA	A/chicken/Egypt/1335S/2013	avian_flu	EPI_ISL_17767310	2013-02-23	Africa	Egypt	New Valley	NA	Chicken	NA
-EPI2584509|A/chicken/Egypt/1331S/2013_HA	A/chicken/Egypt/1331S/2013	avian_flu	EPI_ISL_17767309	2013-02-20	Africa	Egypt	New Valley	NA	Chicken	NA
-EPI2584508|A/chicken/Egypt/1320S/2013_HA	A/chicken/Egypt/1320S/2013	avian_flu	EPI_ISL_17767308	2013-02-07	Africa	Egypt	Suez	NA	Chicken	NA
 EPI2584505|A/chicken/Egypt/CAI37/2009_HA	A/chicken/Egypt/CAI37/2009	avian_flu	EPI_ISL_17767305	2009-05-20	Africa	Egypt	Giza	NA	Chicken	NA
 EPI2584499|A/chicken/Egypt/12107S/2012_HA	A/chicken/Egypt/12107S/2012	avian_flu	EPI_ISL_17767299	2012-10-17	Africa	Egypt	Giza	NA	Chicken	NA
-EPI2584498|A/chicken/Egypt/134/2013_HA	A/chicken/Egypt/134/2013	avian_flu	EPI_ISL_17767298	2013-02-18	Africa	Egypt	Giza	NA	Chicken	NA
-EPI2584497|A/chicken/Egypt/131/2013_HA	A/chicken/Egypt/131/2013	avian_flu	EPI_ISL_17767297	2013-01-28	Africa	Egypt	Giza	NA	Chicken	NA
-EPI2584496|A/chicken/Egypt/13153S/2013_HA	A/chicken/Egypt/13153S/2013	avian_flu	EPI_ISL_17767296	2013-12-09	Africa	Egypt	Giza	NA	Chicken	NA
-EPI2584494|A/chicken/Egypt/1334SD/2013_HA	A/chicken/Egypt/1334SD/2013	avian_flu	EPI_ISL_17767294	2013-02-10	Africa	Egypt	Gharbia	NA	Chicken	NA
 EPI2584492|A/chicken/Egypt/123AS/2012_HA	A/chicken/Egypt/123AS/2012	avian_flu	EPI_ISL_17767292	2012-02-28	Africa	Egypt	Dakahlia	NA	Chicken	NA
-EPI2584490|A/chicken/Egypt/F9519D/2014_HA	A/chicken/Egypt/F9519D/2014	avian_flu	EPI_ISL_17767290	2014-01-27	Africa	Egypt	Dakahlia	NA	Chicken	NA
-EPI2584489|A/chicken/Egypt/F9514E/2014_HA	A/chicken/Egypt/F9514E/2014	avian_flu	EPI_ISL_17767289	2014-01-27	Africa	Egypt	Dakahlia	NA	Chicken	NA
-EPI2584488|A/chicken/Egypt/F9514B/2014_HA	A/chicken/Egypt/F9514B/2014	avian_flu	EPI_ISL_17767288	2014-01-27	Africa	Egypt	Dakahlia	NA	Chicken	NA
-EPI2584487|A/chicken/Egypt/F9514A/2014_HA	A/chicken/Egypt/F9514A/2014	avian_flu	EPI_ISL_17767287	2014-01-27	Africa	Egypt	Dakahlia	NA	Chicken	NA
-EPI2584484|A/chicken/Egypt/13107S/2013_HA	A/chicken/Egypt/13107S/2013	avian_flu	EPI_ISL_17767284	2013-06-20	Africa	Egypt	Cairo	NA	Chicken	NA
-EPI2584483|A/chicken/Egypt/13422F/2013_HA	A/chicken/Egypt/13422F/2013	avian_flu	EPI_ISL_17767283	2013-05-22	Africa	Egypt	Cairo	NA	Chicken	NA
 EPI2584481|A/chicken/Egypt/1237B/2012_HA	A/chicken/Egypt/1237B/2012	avian_flu	EPI_ISL_17767281	2012-02-11	Africa	Egypt	Beni Suef	NA	Chicken	NA
-EPI2584480|A/chicken/Egypt/B9040D/2013_HA	A/chicken/Egypt/B9040D/2013	avian_flu	EPI_ISL_17767280	2013-11-22	Africa	Egypt	Beni Suef	NA	Chicken	NA
-EPI2584479|A/chicken/Egypt/B9040C/2013_HA	A/chicken/Egypt/B9040C/2013	avian_flu	EPI_ISL_17767279	2013-11-22	Africa	Egypt	Beni Suef	NA	Chicken	NA
-EPI2584478|A/chicken/Egypt/B9039A/2013_HA	A/chicken/Egypt/B9039A/2013	avian_flu	EPI_ISL_17767278	2013-11-22	Africa	Egypt	Beni Suef	NA	Chicken	NA
 EPI2584467|A/chicken/Sheny/0606/2008_HA	A/chicken/Sheny/0606/2008	avian_flu	EPI_ISL_17767173	2008-06-06	Asia	China	NA	NA	Chicken	NA
 EPI2584387|A/chicken/Bangladesh/C513_HA/2018_HA	A/chicken/Bangladesh/C513_HA/2018	avian_flu	EPI_ISL_17767092	2018-01-01	Asia	Bangladesh	NA	NA	Chicken	NA
 EPI2584386|A/chicken/Bangladesh/C505_HA/2018_HA	A/chicken/Bangladesh/C505_HA/2018	avian_flu	EPI_ISL_17767091	2018-01-01	Asia	Bangladesh	NA	NA	Chicken	NA
-EPI2584362|A/chicken/Bangladesh/14VIR2665-25/2014_HA	A/chicken/Bangladesh/14VIR2665-25/2014	avian_flu	EPI_ISL_17767068	2014-03-06	Asia	Bangladesh	NA	NA	Chicken	NA
-EPI2584361|A/chicken/Bangladesh/14VIR2665-24/2014_HA	A/chicken/Bangladesh/14VIR2665-24/2014	avian_flu	EPI_ISL_17767067	2014-03-26	Asia	Bangladesh	NA	NA	Chicken	NA
-EPI2584360|A/chicken/Bangladesh/14VIR2665-23/2014_HA	A/chicken/Bangladesh/14VIR2665-23/2014	avian_flu	EPI_ISL_17767066	2014-03-26	Asia	Bangladesh	NA	NA	Chicken	NA
-EPI2584359|A/chicken/Bangladesh/14VIR2665-21/2014_HA	A/chicken/Bangladesh/14VIR2665-21/2014	avian_flu	EPI_ISL_17767065	2014-03-10	Asia	Bangladesh	NA	NA	Chicken	NA
-EPI2584356|A/chicken/Bangladesh/13VIR5602-2/2013_HA	A/chicken/Bangladesh/13VIR5602-2/2013	avian_flu	EPI_ISL_17767062	2013-01-01	Asia	Bangladesh	NA	NA	Chicken	NA
 EPI2584355|A/chicken/Bangladesh/13VIR5602-1/2013_HA	A/chicken/Bangladesh/13VIR5602-1/2013	avian_flu	EPI_ISL_17767061	2013-01-01	Asia	Bangladesh	NA	NA	Chicken	NA
 EPI2580521|A/chicken/Bangladesh/C505-HA/2018	A/chicken/Bangladesh/C505-HA/2018	avian_flu	EPI_ISL_17734234	2018-01-01	Asia	Bangladesh	NA	NA	Chicken	NA
 EPI2580518|A/chicken/Bangladesh/C513-HA/2018	A/chicken/Bangladesh/C513-HA/2018	avian_flu	EPI_ISL_17734231	2018-01-01	Asia	Bangladesh	NA	NA	Chicken	NA
@@ -17498,7 +17332,6 @@ NA	A/chicken/Jogjakarta/bbvet-ix/2004	avian_flu	EPI_ISL_138192	NA	Asia	Indonesia
 NA	A/chicken/Bangladesh/10410/2011	avian_flu	EPI_ISL_138189	NA	Asia	Bangladesh	NA	NA	Chicken	NA
 EPI433309|A/chicken/Hong Kong/AP156/2008	A/chicken/Hong Kong/AP156/2008	avian_flu	EPI_ISL_137553	NA	Asia	China	NA	NA	Chicken	NA
 EPI432653|A/chicken/Nepal/PT-17/12	A/chicken/Nepal/PT-17/12	avian_flu	EPI_ISL_137447	2012-12-18	Asia	Nepal	Kathmandu Valley/Dhading	NA	Chicken	NA
-EPI2579915|A/chicken/Sheny/0606/2008	A/chicken/Sheny/0606/2008	avian_flu	EPI_ISL_121416	2008-06-06	Asia	China	NA	NA	Chicken	NA
 EPI355448|A/chicken/Egypt/VRLCU66/2011	A/chicken/Egypt/VRLCU66/2011	avian_flu	EPI_ISL_105047	NA	Africa	Egypt	NA	NA	Chicken	NA
 EPI314552|A/chicken/Dakahlia/119/2008	A/chicken/Dakahlia/119/2008	avian_flu	EPI_ISL_89267	2008-10-12	Africa	Egypt	NA	NA	Chicken	NA
 EPI314550|A/chicken/Dakahlia/111/2008	A/chicken/Dakahlia/111/2008	avian_flu	EPI_ISL_89266	2008-10-10	Africa	Egypt	NA	NA	Chicken	NA
@@ -17542,10 +17375,7 @@ EPI159887|HA_1709-8	A/chicken/Egypt/1709-8VIR08/2007	avian_flu	EPI_ISL_22791	200
 EPI60652|A/chicken/Ivory_Coast/1787-35/2006	A/chicken/Ivory Coast/1787-35/2006	avian_flu	EPI_ISL_7028	NA	Africa	Cote d'Ivoire	NA	NA	Chicken	NA
 EPI60348|A/chicken/Sudan/2115-10/2006	A/chicken/Sudan/2115-10/2006	avian_flu	EPI_ISL_7014	NA	Africa	Sudan	NA	NA	Chicken	NA
 EPI60310|A/chicken/Afghanistan/1573-7/2006	A/chicken/Afghanistan/1573-7/2006	avian_flu	EPI_ISL_7012	NA	Asia	Afghanistan	NA	NA	Chicken	NA
-EPI58695|A/chicken/Sudan/2115-12/2006	A/chicken/Sudan/2115-12/2006	avian_flu	EPI_ISL_6928	NA	Africa	Sudan	NA	NA	Chicken	NA
-EPI58676|A/chicken/Sudan/2115-9/2006	A/chicken/Sudan/2115-9/2006	avian_flu	EPI_ISL_6927	NA	Africa	Sudan	NA	NA	Chicken	NA
 EPI58657|A/chicken/Sudan/1784-8/2006	A/chicken/Sudan/1784-8/2006	avian_flu	EPI_ISL_6926	NA	Africa	Sudan	NA	NA	Chicken	NA
-EPI58619|A/chicken/Egypt/2253-1/2006	A/chicken/Egypt/2253-1/2006	avian_flu	EPI_ISL_6924	NA	Africa	Egypt	NA	NA	Chicken	NA
 EPI58600|A/chicken/Afghanistan/1573-92/2006	A/chicken/Afghanistan/1573-92/2006	avian_flu	EPI_ISL_6923	NA	Asia	Afghanistan	NA	NA	Chicken	NA
 EPI58581|A/chicken/Afghanistan/1573-65/2006	A/chicken/Afghanistan/1573-65/2006	avian_flu	EPI_ISL_6922	NA	Asia	Afghanistan	NA	NA	Chicken	NA
 EPI58562|A/chicken/Afghanistan/1573-47/2006	A/chicken/Afghanistan/1573-47/2006	avian_flu	EPI_ISL_6921	NA	Asia	Afghanistan	NA	NA	Chicken	NA
@@ -17562,9 +17392,7 @@ EPI47276|A/chicken/Viet_Nam/8/2005	A/chicken/Viet Nam/8/2005	avian_flu	EPI_ISL_6
 EPI47257|A/chicken/Viet_Nam/6/2005	A/chicken/Viet Nam/6/2005	avian_flu	EPI_ISL_6389	NA	Asia	Vietnam	NA	NA	Chicken	NA
 EPI47238|A/chicken/Viet_Nam/2/2005	A/chicken/Viet Nam/2/2005	avian_flu	EPI_ISL_6388	NA	Asia	Vietnam	NA	NA	Chicken	NA
 EPI47181|A/chicken/Cote_d'Ivoire/1787-34/2006	A/chicken/Cote d'Ivoire/1787-34/2006	avian_flu	EPI_ISL_6385	NA	Africa	Cote d'Ivoire	NA	NA	Chicken	NA
-EPI47124|A/chicken/Afghanistan/1207/2006	A/chicken/Afghanistan/1207/2006	avian_flu	EPI_ISL_6382	NA	Asia	Afghanistan	NA	NA	Chicken	NA
 EPI2070249|2022-wk24-12_HA_H5	A/chicken/Netherlands/21038165-006010/2021	avian_flu	EPI_ISL_13360259	2021-11-07	Europe	Netherlands	Provincie Groningen	NA	Gallus gallus	NA
-EPI1925532|A/chicken/Netherlands/21038165-006010/2021	A/chicken/Netherlands/21038165-006010/2021	avian_flu	EPI_ISL_6101848	2021-11-07	Europe	Netherlands	Provincie Groningen	NA	Gallus gallus	Domestic
 EPI1838673|A/chicken/Netherlands/20019879-001005/2020	A/chicken/Netherlands/20019879-001005/2020	avian_flu	EPI_ISL_711055	2020-12-14	Europe	Netherlands	Provincie Friesland	Achtkarspelen	Gallus gallus	Domestic
 EPI355185|A/chicken/EastKalimantan/UT582/2010	A/chicken/EastKalimantan/UT582/2010	avian_flu	EPI_ISL_104854	NA	Asia	Indonesia	East Kalimantan	NA	Gallus gallus	NA
 EPI355184|A/chicken/EastKalimantan/UT581/2010	A/chicken/EastKalimantan/UT581/2010	avian_flu	EPI_ISL_104853	NA	Asia	Indonesia	East Kalimantan	NA	Gallus gallus	NA
@@ -17593,47 +17421,18 @@ EPI2584653|A/duck/Indragiri Hulu/BPPVII 746-12/2012_HA	A/duck/Indragiri Hulu/BPP
 EPI2584652|A/duck/Berau/BPPV5-0513022-B/2013_HA	A/duck/Berau/BPPV5-0513022-B/2013	avian_flu	EPI_ISL_17767710	2013-01-01	Asia	Indonesia	NA	NA	Duck	NA
 EPI2584651|A/duck/Buleleng/BBVD 1451-2-12/2012_HA	A/duck/Buleleng/BBVD 1451-2-12/2012	avian_flu	EPI_ISL_17767709	2012-12-01	Asia	Indonesia	NA	NA	Duck	NA
 EPI2584650|A/duck/Berau/BPPV5-0513022-A/2013_HA	A/duck/Berau/BPPV5-0513022-A/2013	avian_flu	EPI_ISL_17767708	2013-01-01	Asia	Indonesia	NA	NA	Duck	NA
-EPI2584646|A/duck/West Sulawesi/Polman-1018/2012_HA	A/duck/West Sulawesi/Polman-1018/2012	avian_flu	EPI_ISL_17767704	2012-12-01	Asia	Indonesia	NA	NA	Duck	NA
 EPI2584644|A/duck/Trimurjo/BppvIII 12.1182/2012_HA	A/duck/Trimurjo/BppvIII 12.1182/2012	avian_flu	EPI_ISL_17767702	2012-12-01	Asia	Indonesia	NA	NA	Duck	NA
-EPI2584642|A/duck/South Sulawesi/Sidrap-1021/2012_HA	A/duck/South Sulawesi/Sidrap-1021/2012	avian_flu	EPI_ISL_17767700	2012-12-01	Asia	Indonesia	NA	NA	Duck	NA
 EPI2584579|A/duck/Qalubia/CAI11/2010_HA	A/duck/Qalubia/CAI11/2010	avian_flu	EPI_ISL_17767378	2010-03-01	Africa	Egypt	NA	NA	Duck	NA
 EPI2584572|A/duck/Egypt/14154FAOS/2014_HA	A/duck/Egypt/14154FAOS/2014	avian_flu	EPI_ISL_17767370	2014-06-25	Africa	Egypt	NA	NA	Duck	NA
-EPI2584563|A/duck/Egypt/1327SG/2013_HA	A/duck/Egypt/1327SG/2013	avian_flu	EPI_ISL_17767362	2013-02-21	Africa	Egypt	NA	NA	Duck	NA
 EPI2584562|A/duck/Egypt/1316SD/2013_HA	A/duck/Egypt/1316SD/2013	avian_flu	EPI_ISL_17767361	2013-01-16	Africa	Egypt	NA	NA	Duck	NA
-EPI2584560|A/duck/Egypt/13149S/2013_HA	A/duck/Egypt/13149S/2013	avian_flu	EPI_ISL_17767359	2013-11-29	Africa	Egypt	NA	NA	Duck	NA
 EPI2584558|A/duck/Egypt/1310SD/2013_HA	A/duck/Egypt/1310SD/2013	avian_flu	EPI_ISL_17767358	2013-01-16	Africa	Egypt	NA	NA	Duck	NA
 EPI2584557|A/duck/Egypt/1249CA/2012_HA	A/duck/Egypt/1249CA/2012	avian_flu	EPI_ISL_17767357	2012-04-04	Africa	Egypt	NA	NA	Duck	NA
 EPI2584556|A/duck/Egypt/12106S/2012_HA	A/duck/Egypt/12106S/2012	avian_flu	EPI_ISL_17767356	2012-10-16	Africa	Egypt	NA	NA	Duck	NA
-EPI2584555|A/duck/Egypt/132AL/2013_HA	A/duck/Egypt/132AL/2013	avian_flu	EPI_ISL_17767355	2013-02-20	Africa	Egypt	NA	NA	Duck	NA
-EPI2584554|A/duck/Egypt/131AL/2013_HA	A/duck/Egypt/131AL/2013	avian_flu	EPI_ISL_17767354	2013-01-31	Africa	Egypt	NA	NA	Duck	NA
-EPI2584515|A/duck/Egypt/1338S/2013_HA	A/duck/Egypt/1338S/2013	avian_flu	EPI_ISL_17767315	2013-02-27	Africa	Egypt	New Valley	NA	Duck	NA
 EPI2584502|A/duck/Egypt/12143S/2012_HA	A/duck/Egypt/12143S/2012	avian_flu	EPI_ISL_17767302	2012-11-20	Africa	Egypt	Giza	NA	Duck	NA
 EPI2584501|A/duck/Egypt/12133S/2012_HA	A/duck/Egypt/12133S/2012	avian_flu	EPI_ISL_17767301	2012-11-08	Africa	Egypt	Giza	NA	Duck	NA
-EPI2584500|A/duck/Egypt/1313S/2013_HA	A/duck/Egypt/1313S/2013	avian_flu	EPI_ISL_17767300	2013-01-29	Africa	Egypt	Giza	NA	Duck	NA
-EPI2584493|A/duck/Egypt/F7289E/2013_HA	A/duck/Egypt/F7289E/2013	avian_flu	EPI_ISL_17767293	2013-02-05	Africa	Egypt	Faiyum	NA	Duck	NA
 EPI2584468|A/duck/China/1033/2017_HA	A/duck/China/1033/2017	avian_flu	EPI_ISL_17767174	2017-10-20	Asia	China	NA	NA	Duck	NA
-EPI2584393|A/duck/Cambodia/261W7M2/2013_HA	A/duck/Cambodia/261W7M2/2013	avian_flu	EPI_ISL_17767098	2013-02-12	Asia	Cambodia	NA	NA	Duck	NA
-EPI2584392|A/duck/Cambodia/202W6M1/2013_HA	A/duck/Cambodia/202W6M1/2013	avian_flu	EPI_ISL_17767097	2013-02-04	Asia	Cambodia	NA	NA	Duck	NA
-EPI2584391|A/duck/Cambodia/46W2M4/2013_HA	A/duck/Cambodia/46W2M4/2013	avian_flu	EPI_ISL_17767096	2013-01-09	Asia	Cambodia	Khett Kampong Cham	NA	Duck	NA
 EPI2584389|A/Duck/Bangladesh/D094_HA/2018_HA	A/Duck/Bangladesh/D094_HA/2018	avian_flu	EPI_ISL_17767094	2018-01-01	Asia	Bangladesh	NA	NA	Duck	NA
 EPI2584388|A/Duck/Bangladesh/D091_HA/2018_HA	A/Duck/Bangladesh/D091_HA/2018	avian_flu	EPI_ISL_17767093	2018-01-01	Asia	Bangladesh	NA	NA	Duck	NA
-EPI2584383|A/duck/Bangladesh/22115/2014_HA	A/duck/Bangladesh/22115/2014	avian_flu	EPI_ISL_17767088	2014-03-18	Asia	Bangladesh	NA	NA	Duck	NA
-EPI2584382|A/duck/Bangladesh/21980/2014_HA	A/duck/Bangladesh/21980/2014	avian_flu	EPI_ISL_17767087	2014-02-23	Asia	Bangladesh	NA	NA	Duck	NA
-EPI2584381|A/duck/Bangladesh/21970/2014_HA	A/duck/Bangladesh/21970/2014	avian_flu	EPI_ISL_17767086	2014-02-23	Asia	Bangladesh	NA	NA	Duck	NA
-EPI2584380|A/duck/Bangladesh/21909/2014_HA	A/duck/Bangladesh/21909/2014	avian_flu	EPI_ISL_17767085	2014-02-23	Asia	Bangladesh	NA	NA	Duck	NA
-EPI2584379|A/duck/Bangladesh/21908/2014_HA	A/duck/Bangladesh/21908/2014	avian_flu	EPI_ISL_17767084	2014-02-23	Asia	Bangladesh	NA	NA	Duck	NA
-EPI2584378|A/duck/Bangladesh/21907/2014_HA	A/duck/Bangladesh/21907/2014	avian_flu	EPI_ISL_17767083	2014-02-23	Asia	Bangladesh	NA	NA	Duck	NA
-EPI2584377|A/duck/Bangladesh/21814/2014_HA	A/duck/Bangladesh/21814/2014	avian_flu	EPI_ISL_17767082	2014-01-19	Asia	Bangladesh	NA	NA	Duck	NA
-EPI2584376|A/duck/Bangladesh/21469/2013_HA	A/duck/Bangladesh/21469/2013	avian_flu	EPI_ISL_17767081	2013-12-27	Asia	Bangladesh	NA	NA	Duck	NA
-EPI2584375|A/duck/Bangladesh/21329/2013_HA	A/duck/Bangladesh/21329/2013	avian_flu	EPI_ISL_17767080	2013-11-24	Asia	Bangladesh	NA	NA	Duck	NA
-EPI2584374|A/duck/Bangladesh/21327/2013_HA	A/duck/Bangladesh/21327/2013	avian_flu	EPI_ISL_17767079	2013-11-24	Asia	Bangladesh	NA	NA	Duck	NA
-EPI2584373|A/duck/Bangladesh/21326/2013_HA	A/duck/Bangladesh/21326/2013	avian_flu	EPI_ISL_17767078	2013-11-24	Asia	Bangladesh	NA	NA	Duck	NA
-EPI2584372|A/duck/Bangladesh/21269/2013_HA	A/duck/Bangladesh/21269/2013	avian_flu	EPI_ISL_17767077	2013-11-24	Asia	Bangladesh	NA	NA	Duck	NA
-EPI2584370|A/duck/Bangladesh/20399/2013_HA	A/duck/Bangladesh/20399/2013	avian_flu	EPI_ISL_17767076	2013-07-27	Asia	Bangladesh	NA	NA	Duck	NA
-EPI2584366|A/duck/Bangladesh/14VIR1121-18/2013_HA	A/duck/Bangladesh/14VIR1121-18/2013	avian_flu	EPI_ISL_17767072	2013-04-14	Asia	Bangladesh	NA	NA	Duck	NA
-EPI2584365|A/duck/Bangladesh/14VIR1121-17/2013_HA	A/duck/Bangladesh/14VIR1121-17/2013	avian_flu	EPI_ISL_17767071	2013-07-19	Asia	Bangladesh	NA	NA	Duck	NA
-EPI2584364|A/duck/Bangladesh/14VIR1121-16/2013_HA	A/duck/Bangladesh/14VIR1121-16/2013	avian_flu	EPI_ISL_17767070	2013-07-19	Asia	Bangladesh	NA	NA	Duck	NA
-EPI2584363|A/duck/Bangladesh/14VIR1121-12/2013_HA	A/duck/Bangladesh/14VIR1121-12/2013	avian_flu	EPI_ISL_17767069	2013-06-11	Asia	Bangladesh	NA	NA	Duck	NA
 EPI2580520|A/duck/Bangladesh/D094-HA/2018	A/duck/Bangladesh/D094-HA/2018	avian_flu	EPI_ISL_17734233	2018-01-01	Asia	Bangladesh	NA	NA	Duck	NA
 EPI2580519|A/duck/Bangladesh/D091_HA/2018	A/duck/Bangladesh/D091_HA/2018	avian_flu	EPI_ISL_17734232	2018-01-01	Asia	Bangladesh	NA	NA	Duck	NA
 EPI2580407|A/duck/Vietnam/LS-0154/2013	A/duck/Vietnam/LS-0154/2013	avian_flu	EPI_ISL_17734109	2013-05-10	Asia	Vietnam	NA	NA	Duck	NA
@@ -17719,16 +17518,11 @@ EPI48074|A/duck/Viet_Nam/19/2005	A/duck/Viet Nam/19/2005	avian_flu	EPI_ISL_6432	
 EPI47789|A/duck/Viet_Nam/18/2005	A/duck/Viet Nam/18/2005	avian_flu	EPI_ISL_6417	NA	Asia	Vietnam	NA	NA	Duck	NA
 EPI47371|A/duck/Viet_Nam/20/2005	A/duck/Viet Nam/20/2005	avian_flu	EPI_ISL_6395	NA	Asia	Vietnam	NA	NA	Duck	NA
 EPI47352|A/duck/Viet_Nam/12/2005	A/duck/Viet Nam/12/2005	avian_flu	EPI_ISL_6394	NA	Asia	Vietnam	NA	NA	Duck	NA
-EPI47219|A/duck/Viet_Nam/1/2005	A/duck/Viet Nam/1/2005	avian_flu	EPI_ISL_6387	NA	Asia	Vietnam	NA	NA	Duck	NA
 EPI47162|A/duck/Cote_d'Ivoire/1787-18/2006	A/duck/Cote d'Ivoire/1787-18/2006	avian_flu	EPI_ISL_6384	NA	Africa	Cote d'Ivoire	NA	NA	Duck	NA
 EPI751506|A/mallard/Minnesota/AI11-4429/2011	A/mallard/Minnesota/AI11-4429/2011	avian_flu	EPI_ISL_220200	2011-09-15	North America	United States	NA	NA	Anas platyrhynchos	NA
 EPI376143|A/duck/Vietnam/OIE-0062/2012	A/duck/Vietnam/OIE-0062/2012	avian_flu	EPI_ISL_121358	2012-02-19	Asia	Vietnam	NA	NA	Anas platyrhynchos	Domestic
-EPI2579825|A/mallard/Italy/3401/2005, EPI60367|A/mallard/Italy/3401/2005	A/mallard/Italy/3401/2005	avian_flu	EPI_ISL_7015	NA	Europe	Italy	NA	NA	Anas platyrhynchos	NA
-EPI47143|A/mallard/Italy/835/2006	A/mallard/Italy/835/2006	avian_flu	EPI_ISL_6383	NA	Europe	Italy	NA	NA	Anas platyrhynchos	NA
 EPI2162490|A/duck/Bangladesh/50186/2021	A/duck/Bangladesh/50186/2021	avian_flu	EPI_ISL_14884053	2021-10-16	Asia	Bangladesh	NA	NA	Anas sp.	NA
-EPI47694|A/duck/Niger/914/2006	A/duck/Niger/914/2006	avian_flu	EPI_ISL_6412	NA	Africa	Niger	NA	NA	Anas sp.	NA
 EPI2062295|A/white-tailed eagle/Iceland/2022AI02104/2021	A/white-tailed eagle/Iceland/2022AI02104/2021	avian_flu	EPI_ISL_13245602	2021-10-25	Europe	Iceland	Westfjords	Kerlingarfjörður	Eagle	Wild
-NA	A/barn swallow/Hong Kong/1161/2010	avian_flu	EPI_ISL_138226	NA	Asia	Hong Kong (SAR)	NA	NA	Hirundo rustica	NA
 NA	A/crow/Peshawer/narc-7914/2007	avian_flu	EPI_ISL_138225	NA	Asia	Pakistan	NA	NA	Corvus	NA
 NA	A/large billed crow/Hong Kong/497/2011	avian_flu	EPI_ISL_138223	NA	Asia	Hong Kong (SAR)	NA	NA	Corvus macrorhynchos	NA
 EPI3173457|A/Est/Parnu/henharrier/2021	A/Est/Parnu/henharrier/TA21-26003/2021	avian_flu	EPI_ISL_19028670	2021-11-01	Europe	Estonia	Parnumaa	Pärnu, Paikuse	Wild bird	Wild
@@ -17844,13 +17638,6 @@ EPI163120|#163120	A/ruddy_shelduck/Kalmykia/0525/2005 (H5N1)	avian_flu	EPI_ISL_2
 EPI162939|#162939	A/rook/Kurgan/0460/2005 (H5N1)	avian_flu	EPI_ISL_23814	2005-10-03	Europe	Russian Federation	Kurgan Oblast	NA	Other avian	NA
 EPI162938|#162938	A/pigeon/Kurgan/0459/2005 (H5N1)	avian_flu	EPI_ISL_23813	2005-10-03	Europe	Russian Federation	Kurgan Oblast	NA	Other avian	NA
 EPI162921|A/great crested grebe/Germany/R1406/07	A/great crested grebe/Germany/R1406/07	avian_flu	EPI_ISL_23803	NA	Europe	Germany	NA	NA	Other avian	Wild
-EPI253925|A/equine/Egypt/av1/2009	A/equine/Egypt/av1/2009	avian_flu	EPI_ISL_73787	2009-03-24	Africa	Egypt	Beni Suef	Aborady Village	Equine	NA
-EPI2584991|A/environment/Vietnam/HU3-977/2015_HA	A/environment/Vietnam/HU3-977/2015	avian_flu	EPI_ISL_17768778	2015-08-15	Asia	Vietnam	NA	NA	Environment	NA
-EPI2584990|A/environment/Vietnam/HU3-970/2015_HA	A/environment/Vietnam/HU3-970/2015	avian_flu	EPI_ISL_17768777	2015-08-15	Asia	Vietnam	NA	NA	Environment	NA
-EPI2584989|A/environment/Vietnam/HU3-861/2015_HA	A/environment/Vietnam/HU3-861/2015	avian_flu	EPI_ISL_17768776	2015-08-15	Asia	Vietnam	NA	NA	Environment	NA
-EPI2584988|A/environment/Vietnam/HU3-726/2015_HA	A/environment/Vietnam/HU3-726/2015	avian_flu	EPI_ISL_17768775	2015-08-15	Asia	Vietnam	NA	NA	Environment	NA
-EPI2584987|A/environment/Vietnam/HU3-490/2015_HA	A/environment/Vietnam/HU3-490/2015	avian_flu	EPI_ISL_17768774	2015-08-20	Asia	Vietnam	NA	NA	Environment	NA
-EPI2584986|A/environment/Vietnam/HU3-1485/2015_HA	A/environment/Vietnam/HU3-1485/2015	avian_flu	EPI_ISL_17768773	2015-08-15	Asia	Vietnam	NA	NA	Environment	NA
 EPI2584612|A/environment/West Jakarta/BPPVRVIII-344-19/2010_HA	A/environment/West Jakarta/BPPVRVIII-344-19/2010	avian_flu	EPI_ISL_17767670	2010-12-01	Asia	Indonesia	NA	NA	Environment	NA
 EPI2584611|A/environment/South Jakarta/BPPVRVIII-344-20/2010_HA	A/environment/South Jakarta/BPPVRVIII-344-20/2010	avian_flu	EPI_ISL_17767669	2010-12-01	Asia	Indonesia	NA	NA	Environment	NA
 EPI2584610|A/environment/East Jakarta/BPPVRVIII-344-25/2010_HA	A/environment/East Jakarta/BPPVRVIII-344-25/2010	avian_flu	EPI_ISL_17767668	2010-12-01	Asia	Indonesia	NA	NA	Environment	NA
@@ -17862,7 +17649,6 @@ EPI1892853|A/ENVIRONMENT/Hunan/3/2011	A/ENVIRONMENT/Hunan/3/2011	avian_flu	EPI_I
 EPI560202|A/enviroment/Henan/SMX1/2015(H5N1)	A/enviroment/Henan/SMX1/2015(H5N1)	avian_flu	EPI_ISL_171297	2015-01-05	Asia	China	Henan Province	NA	Feces	NA
 EPI251453|A/reassortant/IDCDC-RG13(Egypt/3300-NAMRU3/2008 x Puerto Rico/8/1934)	A/reassortant/IDCDC-RG13(Egypt/3300-NAMRU3/2008 x Puerto Rico/8/1934)	avian_flu	EPI_ISL_73327	NA	North America	United States	NA	NA	Laboratory derived	NA
 EPI1842225|3030944932_ZZYUQJ67_v1_4	A/Laos/2121/2020	avian_flu	EPI_ISL_877035	2020-10-16	Asia	Lao, People's Democratic Republic	NA	NA	Human	NA
-EPI239030|A/Hong Kong/483/1997	A/Hong Kong/483/1997	avian_flu	EPI_ISL_302715	NA	Asia	Hong Kong (SAR)	NA	NA	Human	NA
 EPI1194754|A/Cambodia/Y0219301/2014	A/Cambodia/Y0219301/2014	avian_flu	EPI_ISL_302710	2014-02-10	Asia	Cambodia	Khett Kampong Cham	NA	Human	NA
 EPI610974|A/Thailand/NBL1/2006, EPI610969|A/Thailand/NBL1/2006	A/Thailand/NBL1/2006	avian_flu	EPI_ISL_188694	2006-08-10	Asia	Thailand	NA	NA	Human	NA
 EPI442763|A/Indonesia/NIHRD12550/2012	A/Indonesia/NIHRD12550/2012	avian_flu	EPI_ISL_139510	2012-12-06	Asia	Indonesia	West Java	NA	Human	NA
@@ -17872,7 +17658,6 @@ EPI439901|A/Jiangsu/4/2007	A/Jiangsu/4/2007	avian_flu	EPI_ISL_138871	NA	Asia	Chi
 EPI439899|A/Jiangsu/6/2008	A/Jiangsu/6/2008	avian_flu	EPI_ISL_138869	NA	Asia	China	NA	NA	Human	NA
 EPI356474|11949	A/Indonesia/NIHRD11949/2012	avian_flu	EPI_ISL_105990	2012-01-13	Asia	Indonesia	Jakarta	NA	Human	NA
 EPI356472|11931	A/Indonesia/NIHRD11931/2012	avian_flu	EPI_ISL_105989	2012-01-07	Asia	Indonesia	Jakarta	NA	Human	NA
-EPI317081|A/Cambodia/408008/2005	A/Cambodia/408008/2005	avian_flu	EPI_ISL_90136	NA	Asia	Cambodia	NA	NA	Human	NA
 EPI314775|A/Bangladesh/3233/2011	A/Bangladesh/3233/2011	avian_flu	EPI_ISL_89366	2011-03-09	Asia	Bangladesh	NA	NA	Human	NA
 EPI280032|A/Anhui/1/2006.4	A/Anhui/1/2006	avian_flu	EPI_ISL_73320	2006-12-10	Asia	China	Anhui Province	Tunxi	Human	NA
 NA	A/Hunan/1/2006	avian_flu	EPI_ISL_73319	2006-01-27	Asia	China	Hunan Province	NA	Human	NA
@@ -17905,23 +17690,11 @@ NA	A/Anhui/2/2005	avian_flu	EPI_ISL_73293	2005-11-11	Asia	China	Anhui Province	N
 EPI165076|A/Egypt/10216-NAMRU3/2007	A/Egypt/10216-NAMRU3/2007	avian_flu	EPI_ISL_24878	2007-12-29	Africa	Egypt	NA	NA	Human	NA
 EPI165075|A/Egypt/10215-NAMRU3/2007	A/Egypt/10215-NAMRU3/2007	avian_flu	EPI_ISL_24877	2007-12-26	Africa	Egypt	NA	NA	Human	NA
 EPI165074|A/Egypt/10211-NAMRU3/2007	A/Egypt/10211-NAMRU3/2007	avian_flu	EPI_ISL_24876	2007-12-24	Africa	Egypt	Beni Suef	Markaz Bani Suwayf	Human	NA
-EPI165073|A/Egypt/3401-NAMRU3/2008	A/Egypt/3401-NAMRU3/2008	avian_flu	EPI_ISL_24875	2008-04-16	Africa	Egypt	Cairo	Cairo	Human	NA
-EPI165072|A/Egypt/3300-NAMRU3/2008	A/Egypt/3300-NAMRU3/2008	avian_flu	EPI_ISL_24874	2008-04-11	Africa	Egypt	Cairo	Cairo	Human	NA
 EPI165071|A/Egypt/3158-NAMRU3/2008	A/Egypt/3158-NAMRU3/2008	avian_flu	EPI_ISL_24873	2008-04-05	Africa	Egypt	Alexandria	NA	Human	NA
-EPI165070|A/Egypt/2546-NAMRU3/2008	A/Egypt/2546-NAMRU3/2008	avian_flu	EPI_ISL_24872	2008-03-08	Africa	Egypt	Faiyum	NA	Human	NA
 EPI165069|A/Egypt/2514-NAMRU3/2008	A/Egypt/2514-NAMRU3/2008	avian_flu	EPI_ISL_24871	2008-03-04	Africa	Egypt	NA	NA	Human	NA
-EPI165068|A/Egypt/2289-NAMRU3/2008	A/Egypt/2289-NAMRU3/2008	avian_flu	EPI_ISL_24870	2008-03-02	Africa	Egypt	Faiyum	NA	Human	NA
-EPI165067|A/Egypt/1980-NAMRU3/2008	A/Egypt/1980-NAMRU3/2008	avian_flu	EPI_ISL_24869	2008-02-26	Africa	Egypt	NA	NA	Human	NA
 EPI165065|A/Cambodia/R0405050/2007	A/Cambodia/R0405050/2007	avian_flu	EPI_ISL_24868	2007-04-04	Asia	Cambodia	Khett Kampong Cham	Kampong Cham	Human	NA
 EPI164763|HA_7272	A/Indonesia/7272/2008	avian_flu	EPI_ISL_24753	NA	Asia	Indonesia	Banten	NA	Human	NA
 EPI164755|7379	A/Indonesia/7379/2008	avian_flu	EPI_ISL_24752	NA	Asia	Indonesia	Banten	NA	Human	NA
-EPI164266|#164266	A/Jiangxi/1/2005	avian_flu	EPI_ISL_24609	2005-12-10	Asia	China	Jiangxi Province	NA	Human	NA
-EPI164258|#164258	A/Guangxi/1/2005	avian_flu	EPI_ISL_24608	2005-11-29	Asia	China	Guangxi Zhuang Autonomous Region	NA	Human	NA
-EPI164250|#164250	A/Fujian/1/2005	avian_flu	EPI_ISL_24607	2005-12-12	Asia	China	Fujian Province	NA	Human	NA
-EPI164240|#164240	A/Anhui/2/2005	avian_flu	EPI_ISL_24606	2005-11-17	Asia	China	Anhui Province	NA	Human	NA
-EPI164232|#164232	A/Sichuan/2/2006	avian_flu	EPI_ISL_24605	2006-01-17	Asia	China	Sichuan Province	NA	Human	NA
-EPI164224|#164224	A/Sichuan/1/2006	avian_flu	EPI_ISL_24604	2006-01-11	Asia	China	Sichuan Province	NA	Human	NA
-EPI164216|#164216	A/Anhui/1/2005	avian_flu	EPI_ISL_24603	2005-11-08	Asia	China	Anhui Province	NA	Human	NA
 EPI164208|8228_HA	A/Indonesia/8228/2008	avian_flu	EPI_ISL_24602	2008-05-08	Asia	Indonesia	Banten	NA	Human	NA
 EPI162940|7261_HA_full	A/Indonesia/7261/2008	avian_flu	EPI_ISL_23815	2008-01-16	Asia	Indonesia	Banten	NA	Human	NA
 EPI3298052|A/Mixed/NL/FAV-0004-16/2022_HA	A/Mixed/NL/FAV-0004-16/2022	avian_flu	EPI_ISL_19145144	2021-12-31	North America	Canada	NL	NA	Avian	NA
@@ -17941,9 +17714,6 @@ EPI3297948|A/Mixed/NL/FAV-0035-5/2021_HA	A/Mixed/NL/FAV-0035-5/2021	avian_flu	EP
 EPI3297940|A/Mixed/NL/FAV-0035-4/2021_HA	A/Mixed/NL/FAV-0035-4/2021	avian_flu	EPI_ISL_19145130	2021-12-16	North America	Canada	NL	NA	Avian	NA
 EPI3297932|A/Mixed/NL/FAV-0035-3/2021_HA	A/Mixed/NL/FAV-0035-3/2021	avian_flu	EPI_ISL_19145129	2021-12-16	North America	Canada	NL	NA	Avian	NA
 EPI3297924|A/Mixed/NL/FAV-0035-2/2021_HA	A/Mixed/NL/FAV-0035-2/2021	avian_flu	EPI_ISL_19145128	2021-12-16	North America	Canada	NL	NA	Avian	NA
-EPI2585054|A/swallow/Vietnam/NT25/2013_HA	A/swallow/Vietnam/NT25/2013	avian_flu	EPI_ISL_17768841	2013-04-07	Asia	Vietnam	NA	NA	Avian	NA
-EPI2585053|A/swallow/Vietnam/NT24/2013_HA	A/swallow/Vietnam/NT24/2013	avian_flu	EPI_ISL_17768840	2013-04-07	Asia	Vietnam	NA	NA	Avian	NA
-EPI2585052|A/swallow/Vietnam/NT22/2013_HA	A/swallow/Vietnam/NT22/2013	avian_flu	EPI_ISL_17768839	2013-04-07	Asia	Vietnam	NA	NA	Avian	NA
 EPI2585051|A/muscovy duck/Vietnam/LS154/2013_HA	A/muscovy duck/Vietnam/LS154/2013	avian_flu	EPI_ISL_17768838	2013-01-10	Asia	Vietnam	NA	NA	Avian	NA
 EPI2584985|A/Muscovy duck/Vietnam/HU3-Z2/2015_HA	A/Muscovy duck/Vietnam/HU3-Z2/2015	avian_flu	EPI_ISL_17768772	2015-08-15	Asia	Vietnam	NA	NA	Avian	NA
 EPI2584984|A/Muscovy duck/Vietnam/HU3-Z10/2015_HA	A/Muscovy duck/Vietnam/HU3-Z10/2015	avian_flu	EPI_ISL_17768771	2015-08-15	Asia	Vietnam	NA	NA	Avian	NA
@@ -17959,10 +17729,6 @@ EPI2584975|A/Muscovy duck/Vietnam/HU3-1408/2015_HA	A/Muscovy duck/Vietnam/HU3-14
 EPI2584974|A/Muscovy duck/Vietnam/HU3-1403/2015_HA	A/Muscovy duck/Vietnam/HU3-1403/2015	avian_flu	EPI_ISL_17768761	2015-08-15	Asia	Vietnam	NA	NA	Avian	NA
 EPI2584973|A/Muscovy duck/Vietnam/HU3-1360/2015_HA	A/Muscovy duck/Vietnam/HU3-1360/2015	avian_flu	EPI_ISL_17768760	2015-08-15	Asia	Vietnam	NA	NA	Avian	NA
 EPI2584972|A/Muscovy duck/Vietnam/HU3-1079/2015_HA	A/Muscovy duck/Vietnam/HU3-1079/2015	avian_flu	EPI_ISL_17768759	2015-08-15	Asia	Vietnam	NA	NA	Avian	NA
-EPI2584962|A/goose/Vietnam/HU10-1141/2018_HA	A/goose/Vietnam/HU10-1141/2018	avian_flu	EPI_ISL_17768749	2018-08-28	Asia	Vietnam	NA	NA	Avian	NA
-EPI2584961|A/quail/Vietnam/CVVI-50/2014_HA	A/quail/Vietnam/CVVI-50/2014	avian_flu	EPI_ISL_17768748	2014-02-25	Asia	Vietnam	NA	NA	Avian	NA
-EPI2584960|A/quail/Vietnam/CVVI-49/2010_HA	A/quail/Vietnam/CVVI-49/2010	avian_flu	EPI_ISL_17768730	2010-01-10	Asia	Vietnam	NA	NA	Avian	NA
-EPI2584597|A/crow/India/01CA15/2012_HA	A/crow/India/01CA15/2012	avian_flu	EPI_ISL_17767514	2012-01-09	Asia	India	NA	NA	Avian	NA
 EPI2584592|A/thick-billed_murre/Greenland/9045-2K/2014_HA	A/thick-billed_murre/Greenland/9045-2K/2014	avian_flu	EPI_ISL_17767509	2014-02-01	North America	Greenland	NA	NA	Avian	NA
 EPI2182152|A/wigeon/Sakhalin/37M/2021	A/wigeon/Sakhalin/37M/2021	avian_flu	EPI_ISL_15081424	2021-09-17	Europe	Russian Federation	NA	NA	Avian	Wild
 EPI2167247|A/Sacred ibis/South Africa/21060395/2021 (H5N1)	A/Sacred ibis/South Africa/21060395/2021 (H5N1)	avian_flu	EPI_ISL_14918031	2021-06-19	Africa	South Africa	Province of the Western Cape	Hermanus	Avian	Wild
@@ -17972,16 +17738,6 @@ EPI2040474|07S1134	A/Duck/Nighe An/NCVD-50/2007	avian_flu	EPI_ISL_12721623	NA	As
 EPI1938836|A/common buzzard/Sweden/SVA211111SZ0376/FB004484/2021	A/common buzzard/Sweden/SVA211111SZ0376/FB004484/2021	avian_flu	EPI_ISL_7053000	2021-11-09	Europe	Sweden	Skane Lan	Malmo Kommun	Avian	Wild
 EPI356783|A/bird/Turkey/Unye ist06/2006	A/bird/Turkey/Unye ist06/2006	avian_flu	EPI_ISL_106281	2006-03-07	Asia	Turkey	NA	NA	Avian	NA
 EPI356558|A/Muscovy duck/West Java/Bgr-Cw/2005	A/Muscovy duck/West Java/Bgr-Cw/2005	avian_flu	EPI_ISL_106081	NA	Asia	Indonesia	NA	NA	Avian	NA
-EPI2585001|A/chicken/Vietnam/HU3-Z12/2015_HA	A/chicken/Vietnam/HU3-Z12/2015	avian_flu	EPI_ISL_17768788	2015-08-15	Asia	Vietnam	NA	NA	Chicken	NA
-EPI2585000|A/chicken/Vietnam/HU3-885/2015_HA	A/chicken/Vietnam/HU3-885/2015	avian_flu	EPI_ISL_17768787	2015-08-15	Asia	Vietnam	NA	NA	Chicken	NA
-EPI2584999|A/chicken/Vietnam/HU3-879/2015_HA	A/chicken/Vietnam/HU3-879/2015	avian_flu	EPI_ISL_17768786	2015-08-15	Asia	Vietnam	NA	NA	Chicken	NA
-EPI2584998|A/chicken/Vietnam/HU3-800/2015_HA	A/chicken/Vietnam/HU3-800/2015	avian_flu	EPI_ISL_17768785	2015-08-15	Asia	Vietnam	NA	NA	Chicken	NA
-EPI2584997|A/chicken/Vietnam/HU3-770/2015_HA	A/chicken/Vietnam/HU3-770/2015	avian_flu	EPI_ISL_17768784	2015-08-15	Asia	Vietnam	NA	NA	Chicken	NA
-EPI2584996|A/chicken/Vietnam/HU3-737/2015_HA	A/chicken/Vietnam/HU3-737/2015	avian_flu	EPI_ISL_17768783	2015-08-15	Asia	Vietnam	NA	NA	Chicken	NA
-EPI2584995|A/chicken/Vietnam/HU3-721/2015_HA	A/chicken/Vietnam/HU3-721/2015	avian_flu	EPI_ISL_17768782	2015-08-15	Asia	Vietnam	NA	NA	Chicken	NA
-EPI2584994|A/chicken/Vietnam/HU3-1518/2015_HA	A/chicken/Vietnam/HU3-1518/2015	avian_flu	EPI_ISL_17768781	2015-08-15	Asia	Vietnam	NA	NA	Chicken	NA
-EPI2584993|A/chicken/Vietnam/HU3-1317/2015_HA	A/chicken/Vietnam/HU3-1317/2015	avian_flu	EPI_ISL_17768780	2015-08-15	Asia	Vietnam	NA	NA	Chicken	NA
-EPI2584992|A/chicken/Vietnam/HU3-1308/2015_HA	A/chicken/Vietnam/HU3-1308/2015	avian_flu	EPI_ISL_17768779	2015-08-15	Asia	Vietnam	NA	NA	Chicken	NA
 EPI2584621|A/chicken/Bartim/BPPVRV-126-4/2011_HA	A/chicken/Bartim/BPPVRV-126-4/2011	avian_flu	EPI_ISL_17767679	2011-04-01	Asia	Indonesia	NA	NA	Chicken	NA
 EPI2584620|A/chicken/Bangli/BBVD-0245A-4/2011_HA	A/chicken/Bangli/BBVD-0245A-4/2011	avian_flu	EPI_ISL_17767678	2011-04-01	Asia	Indonesia	NA	NA	Chicken	NA
 EPI2584619|A/chicken/Tabanan/BBVD-0178-3/2011_HA	A/chicken/Tabanan/BBVD-0178-3/2011	avian_flu	EPI_ISL_17767677	2011-03-01	Asia	Indonesia	NA	NA	Chicken	NA
@@ -17996,10 +17752,6 @@ EPI2584604|A/chicken/Pasaman/BBPPVRII-656/2009_HA	A/chicken/Pasaman/BBPPVRII-656
 EPI2584603|A/chicken/Sarolangun/BPPVRII-187/2009_HA	A/chicken/Sarolangun/BPPVRII-187/2009	avian_flu	EPI_ISL_17767661	2009-03-01	Asia	Indonesia	NA	NA	Chicken	NA
 EPI2584602|A/chicken/Pare/Pusvetma/2005_HA	A/chicken/Pare/Pusvetma/2005	avian_flu	EPI_ISL_17767660	2005-01-01	Asia	Indonesia	NA	NA	Chicken	NA
 EPI2584601|A/chicken/WestJava(Sbg)/29/2007(H5N1)_HA	A/chicken/WestJava(Sbg)/29/2007(H5N1)	avian_flu	EPI_ISL_17767659	2007-01-01	Asia	Indonesia	NA	NA	Chicken	NA
-EPI2584600|A/chicken/Indonesia/4998T/2018_HA	A/chicken/Indonesia/4998T/2018	avian_flu	EPI_ISL_17767658	2018-07-29	Asia	Indonesia	NA	NA	Chicken	NA
-EPI2584598|A/chicken/Gorontalo/BBVM-228-10/2011_HA	A/chicken/Gorontalo/BBVM-228-10/2011	avian_flu	EPI_ISL_17767656	2011-03-01	Asia	Indonesia	Gorontalo	NA	Chicken	NA
-EPI2584596|A/chicken/India/04CA01/2015_HA	A/chicken/India/04CA01/2015	avian_flu	EPI_ISL_17767513	2015-04-01	Asia	India	NA	NA	Chicken	NA
-EPI2584595|A/chicken/India/100074/2008_HA	A/chicken/India/100074/2008	avian_flu	EPI_ISL_17767512	2008-03-01	Asia	India	NA	NA	Chicken	NA
 EPI2415855|A/chicken/Ghana/AVL-763_21VIR7050-39/2021_HA	A/chicken/Ghana/AVL-763_21VIR7050-39/2021	avian_flu	EPI_ISL_16997921	2021-06-08	Africa	Ghana	NA	NA	Chicken	NA
 EPI2146037|A/chicken/Lesotho/352.3/2021	A/chicken/Lesotho/352.3/2021	avian_flu	EPI_ISL_14769967	2021-06-05	Africa	Lesotho	NA	NA	Chicken	NA
 EPI2146029|A/chicken/Lesotho/341.10/2021	A/chicken/Lesotho/341.10/2021	avian_flu	EPI_ISL_14769966	2021-05-29	Africa	Lesotho	NA	NA	Chicken	NA
@@ -18296,20 +18048,8 @@ EPI2585056|A/duck/VietNam/TMU027/2009_HA	A/duck/VietNam/TMU027/2009	avian_flu	EP
 EPI2585055|A/duck/VietNam/TMU024/2009_HA	A/duck/VietNam/TMU024/2009	avian_flu	EPI_ISL_17768842	2009-12-10	Asia	Vietnam	NA	NA	Duck	NA
 EPI2585050|A/Muscovy duck/Vietnam/BG80-2/2013_HA	A/Muscovy duck/Vietnam/BG80-2/2013	avian_flu	EPI_ISL_17768837	2013-05-02	Asia	Vietnam	NA	NA	Duck	NA
 EPI2585049|A/Muscovy duck/Vietnam/BG80-1/2013_HA	A/Muscovy duck/Vietnam/BG80-1/2013	avian_flu	EPI_ISL_17768836	2013-05-02	Asia	Vietnam	NA	NA	Duck	NA
-EPI2585048|A/duck/Vietnam/QT1479/2012_HA	A/duck/Vietnam/QT1479/2012	avian_flu	EPI_ISL_17768835	2012-02-03	Asia	Vietnam	NA	NA	Duck	NA
-EPI2585047|A/duck/Vietnam/QT1458-2/2012_HA	A/duck/Vietnam/QT1458-2/2012	avian_flu	EPI_ISL_17768834	2012-01-25	Asia	Vietnam	NA	NA	Duck	NA
-EPI2585046|A/duck/Vietnam/LS101/2013_HA	A/duck/Vietnam/LS101/2013	avian_flu	EPI_ISL_17768833	2013-01-05	Asia	Vietnam	NA	NA	Duck	NA
 EPI2585013|A/muscovy duck/Vietnam/QN-1440/2014_HA	A/muscovy duck/Vietnam/QN-1440/2014	avian_flu	EPI_ISL_17768800	2014-04-15	Asia	Vietnam	NA	NA	Duck	NA
 EPI2585011|A/muscovy duck/Vietnam/LS-0154/2013_HA	A/muscovy duck/Vietnam/LS-0154/2013	avian_flu	EPI_ISL_17768798	2013-05-10	Asia	Vietnam	NA	NA	Duck	NA
-EPI2584971|A/duck/Vietnam/HU3-898/2015_HA	A/duck/Vietnam/HU3-898/2015	avian_flu	EPI_ISL_17768758	2015-08-15	Asia	Vietnam	NA	NA	Duck	NA
-EPI2584970|A/duck/Vietnam/HU3-708/2015_HA	A/duck/Vietnam/HU3-708/2015	avian_flu	EPI_ISL_17768757	2015-08-15	Asia	Vietnam	NA	NA	Duck	NA
-EPI2584969|A/duck/Vietnam/HU3-617/2015_HA	A/duck/Vietnam/HU3-617/2015	avian_flu	EPI_ISL_17768756	2015-08-15	Asia	Vietnam	NA	NA	Duck	NA
-EPI2584968|A/duck/Vietnam/HU3-574/2015_HA	A/duck/Vietnam/HU3-574/2015	avian_flu	EPI_ISL_17768755	2015-08-15	Asia	Vietnam	NA	NA	Duck	NA
-EPI2584967|A/duck/Vietnam/HU3-567/2015_HA	A/duck/Vietnam/HU3-567/2015	avian_flu	EPI_ISL_17768754	2015-08-15	Asia	Vietnam	NA	NA	Duck	NA
-EPI2584966|A/duck/Vietnam/HU3-408/2015_HA	A/duck/Vietnam/HU3-408/2015	avian_flu	EPI_ISL_17768753	2015-08-15	Asia	Vietnam	NA	NA	Duck	NA
-EPI2584965|A/duck/Vietnam/HU3-386/2015_HA	A/duck/Vietnam/HU3-386/2015	avian_flu	EPI_ISL_17768752	2015-08-15	Asia	Vietnam	NA	NA	Duck	NA
-EPI2584964|A/duck/Vietnam/HU3-1265/2015_HA	A/duck/Vietnam/HU3-1265/2015	avian_flu	EPI_ISL_17768751	2015-08-15	Asia	Vietnam	NA	NA	Duck	NA
-EPI2584963|A/duck/Vietnam/HU3-1126/2015_HA	A/duck/Vietnam/HU3-1126/2015	avian_flu	EPI_ISL_17768750	2015-08-15	Asia	Vietnam	NA	NA	Duck	NA
 EPI2584896|A/mallard/Iowa/568/1982_HA	A/mallard/Iowa/568/1982	avian_flu	EPI_ISL_17768587	1982-01-01	North America	United States	Iowa	NA	Duck	NA
 EPI2584607|A/muscovy duck/Sleman/BBVW-180-III/2010_HA	A/muscovy duck/Sleman/BBVW-180-III/2010	avian_flu	EPI_ISL_17767665	2010-03-01	Asia	Indonesia	NA	NA	Duck	NA
 EPI2132674|A/Egyptian goose/South Africa/21050245A/2021 (H5N1)	A/Egyptian goose/South Africa/21050245A/2021 (H5N1)	avian_flu	EPI_ISL_14573124	2021-05-13	Africa	South Africa	Province of the Western Cape	Worcester	Duck	Wild
@@ -18520,7 +18260,6 @@ EPI503718|A/Japanese white-eye/Taoyuan/Q454/2012	A/Japanese white-eye/Taoyuan/Q4
 EPI2134190|A/African penguin/South Africa/21050383/2021 (H5N1)	A/African penguin/South Africa/21050383/2021 (H5N1)	avian_flu	EPI_ISL_14638909	2021-05-20	Africa	South Africa	Province of the Western Cape	Cape Town	Penguin	Wild
 EPI1947271|A/mallard/Italy/21VIR6957-6/2021_H5N1_HA	A/mallard/Italy/21VIR6957-6/2021	avian_flu	EPI_ISL_7987333	2021-08-20	Europe	Italy	NA	NA	Mallard	NA
 EPI1902596|A/Mallard(Anas platyrhynchos)/South Korea/KNU2019-20/2019	A/Mallard(Anas platyrhynchos)/South Korea/KNU2019-20/2019	avian_flu	EPI_ISL_4071029	2019-03-03	Asia	Korea, Republic of	NA	NA	Mallard	NA
-EPI2584594|A/ruddy turnstone/Iceland/2899/2013_HA	A/ruddy turnstone/Iceland/2899/2013	avian_flu	EPI_ISL_17767511	2013-05-23	Europe	Iceland	NA	NA	Turnstone	NA
 EPI1647382|A/muscovy_duck/East_Java/Av1492/2019	A/muscovy_duck/East_Java/Av1492/2019	avian_flu	EPI_ISL_401829	2019-01-16	Asia	Indonesia	East Java	Jombang	Cairina moschata	Domestic
 EPI1647374|A/muscovy_duck/East_Java/Av1576/2019	A/muscovy_duck/East_Java/Av1576/2019	avian_flu	EPI_ISL_401828	2019-02-02	Asia	Indonesia	East Java	Sidoarjo	Cairina moschata	Domestic
 EPI1647318|A/muscovy_duck/East_Java/Av252/2014	A/muscovy_duck/East_Java/Av252/2014	avian_flu	EPI_ISL_401821	2014-02-02	Asia	Indonesia	East Java	NA	Cairina moschata	Domestic
@@ -18550,18 +18289,12 @@ EPI1943070|23589-1ST H5	A/chicken/Czech Republic/23589-1T/2021	avian_flu	EPI_ISL
 EPI1943054|23404-4T H5	A/chicken/Czech Republic/23404-4T/2021	avian_flu	EPI_ISL_7626513	2021-11-25	Europe	Czech Republic	South Moravian Region	Okres Breclav	Gallus gallus domesticus	Domestic
 EPI1943046|23404-2T H5	A/chicken/Czech Republic/23404-2T/2021	avian_flu	EPI_ISL_7626512	2021-11-25	Europe	Czech Republic	South Moravian Region	Okres Breclav	Gallus gallus domesticus	Domestic
 EPI1943030|23404-2K H5	A/chicken/Czech Republic/23404-2K/2021	avian_flu	EPI_ISL_7626484	2021-11-25	Europe	Czech Republic	South Moravian Region	Lednice; ZipCode:69103	Gallus gallus domesticus	Domestic
-EPI1922981|211022_76_H5N1_Seg4_HA	A/chicken/Tyumen/33-45V/2021	avian_flu	EPI_ISL_5463804	2021-10-07	Europe	Russian Federation	Tyumen Oblast	Tyumen	Gallus gallus domesticus	NA
 EPI1922957|211022_73_H5N1_Seg4_HA	A/chicken/Saratov/29-07V/2021	avian_flu	EPI_ISL_5463801	2021-09-30	Europe	Russian Federation	Saratov Oblast	Saratov	Gallus gallus domesticus	NA
 EPI1922949|211022_72_H5N1_Seg4_HA	A/chicken/Saratov/29-06V/2021	avian_flu	EPI_ISL_5463800	2021-09-30	Europe	Russian Federation	Saratov Oblast	Saratov	Gallus gallus domesticus	NA
-EPI1922917|211022_68_H5N1_Seg4_HA	A/chicken/Tyumen/27-42V/2021	avian_flu	EPI_ISL_5463796	2021-10-06	Europe	Russian Federation	Tyumen Oblast	Tyumen	Gallus gallus domesticus	NA
 EPI1922909|211022_67_H5N1_Seg4_HA	A/chicken/Tyumen/27-40V/2021	avian_flu	EPI_ISL_5463795	2021-10-06	Europe	Russian Federation	Tyumen Oblast	Tyumen	Gallus gallus domesticus	NA
-EPI1922901|211022_66_H5N1_Seg4_HA	A/chicken/Tyumen/27-39V/2021	avian_flu	EPI_ISL_5463794	2021-10-06	Europe	Russian Federation	Tyumen Oblast	Tyumen	Gallus gallus domesticus	NA
-EPI1922893|211022_65_H5N1_Seg4_HA	A/chicken/Tyumen/27-31V/2021	avian_flu	EPI_ISL_5463793	2021-10-06	Europe	Russian Federation	Tyumen Oblast	Tyumen	Gallus gallus domesticus	NA
 EPI1892852|A/PIGEON/Hunan/185/2010	A/PIGEON/Hunan/185/2010	avian_flu	EPI_ISL_4055148	2010-01-01	Asia	China	Hunan Province	NA	Pigeon	NA
 EPI1927689|A/goose/Czech Republic/20689-28T/2021	A/goose/Czech Republic/20689-28T/2021	avian_flu	EPI_ISL_6512576	2021-10-22	Europe	Czech Republic	Vysocina Kraj	Okres Jihlava	Anser anser domesticus	Domestic
 EPI1927681|A/goose/Czech Republic/20689-27T/2021	A/goose/Czech Republic/20689-27T/2021	avian_flu	EPI_ISL_6511912	2021-10-22	Europe	Czech Republic	Vysocina Kraj	Okres Jihlava	Anser anser domesticus	Domestic
-EPI1922997|211022_78_H5N1_Seg4_HA	A/goose/Tyumen/33-53V/2021	avian_flu	EPI_ISL_5463806	2021-10-07	Europe	Russian Federation	Tyumen Oblast	Tyumen	Anser anser domesticus	NA
-EPI1922989|211022_77_H5N1_Seg4_HA	A/goose/Tyumen/33-52V/2021	avian_flu	EPI_ISL_5463805	2021-10-07	Europe	Russian Federation	Tyumen Oblast	Tyumen	Anser anser domesticus	NA
 EPI1903402|A/quail/Bangladesh/41266/2019	A/quail/Bangladesh/41266/2019	avian_flu	EPI_ISL_4071837	2019-12-11	Asia	Bangladesh	NA	NA	Coturnix sp.	NA
 EPI1922973|211022_75_H5N1_Seg4_HA	A/duck/Saratov/29-11V/2021	avian_flu	EPI_ISL_5463803	2021-09-30	Europe	Russian Federation	Saratov Oblast	Saratov	Anas platyrhynchos f. domestica	NA
 EPI1922965|211022_74_H5N1_Seg4_HA	A/duck/Saratov/29-08V/2021	avian_flu	EPI_ISL_5463802	2021-09-30	Europe	Russian Federation	Saratov Oblast	Saratov	Anas platyrhynchos f. domestica	NA
@@ -18637,7 +18370,6 @@ EPI1987722|A/long-eared owl/Germany-NI/AI09037/2021	A/long-eared owl/Germany-NI/
 EPI1941418|2021-wk48-24_HA_H5	A/grey heron/Netherlands/21038941-001/2021	avian_flu	EPI_ISL_7267249	2021-11-15	Europe	Netherlands	Provincie Gelderland	NA	Other avian	NA
 NA	A/pigeon/Bukittinggi/BPPVRII-178-B/2007	avian_flu	EPI_ISL_139839	2007-03-26	Asia	Indonesia	NA	NA	Other avian	NA
 EPI384245|A/parrot/Guangdong/C99/2005	A/parrot/Guangdong/C99/2005	avian_flu	EPI_ISL_124331	2005-02-01	Asia	China	NA	NA	Other avian	NA
-EPI384241|A/great crested grebe/Sevastopol/11-173/2008	A/great crested grebe/Sevastopol/11-173/2008	avian_flu	EPI_ISL_124328	NA	Europe	Ukraine	NA	NA	Other avian	NA
 EPI384238|A/cormorant/Strilkove-Kherson/63/2006	A/cormorant/Strilkove-Kherson/63/2006	avian_flu	EPI_ISL_124326	NA	Europe	Ukraine	NA	NA	Other avian	NA
 EPI383276|A/condor/Guangdong/139/2003	A/condor/Guangdong/139/2003	avian_flu	EPI_ISL_123967	2003-01-23	Asia	China	NA	NA	Other avian	NA
 EPI321750|A/peaceful dove/Denpasar/BBVD-480/2007	A/peaceful dove/Denpasar/BBVD-480/2007	avian_flu	EPI_ISL_91624	2007-08-23	Asia	Indonesia	NA	NA	Other avian	NA
@@ -18697,7 +18429,6 @@ EPI954435|A/Cambodia/Y0208301/2014	A/Cambodia/Y0208301/2014	avian_flu	EPI_ISL_25
 EPI383626|A/Indonesia/UT3006/2005	A/Indonesia/UT3006/2005	avian_flu	EPI_ISL_124114	NA	Asia	Indonesia	NA	NA	Human	NA
 EPI255420|A/Egypt/N15262/2009	A/Egypt/N15262/2009	avian_flu	EPI_ISL_74343	NA	Africa	Egypt	NA	NA	Human	NA
 NA	A/Egypt/N14604/2009	avian_flu	EPI_ISL_74342	2009-12-19	Africa	Egypt	NA	NA	Human	NA
-EPI255411|A/Egypt/N11981/2009	A/Egypt/N11981/2009	avian_flu	EPI_ISL_74335	2009-11-22	Africa	Egypt	NA	NA	Human	NA
 EPI255400|A/Egypt/N09539/2009	A/Egypt/N09539/2009	avian_flu	EPI_ISL_74325	2009-09-16	Africa	Egypt	NA	NA	Human	NA
 EPI255398|A/Egypt/N09174/2009	A/Egypt/N09174/2009	avian_flu	EPI_ISL_74324	2009-08-26	Africa	Egypt	NA	NA	Human	NA
 EPI255394|A/Egypt/N08835/2009	A/Egypt/N08835/2009	avian_flu	EPI_ISL_74321	2009-08-01	Africa	Egypt	NA	NA	Human	NA
@@ -18707,15 +18438,7 @@ EPI255388|A/Egypt/N05912/2009	A/Egypt/N05912/2009	avian_flu	EPI_ISL_74318	2009-0
 NA	A/Egypt/N05049/2009	avian_flu	EPI_ISL_74317	2009-06-02	Africa	Egypt	NA	NA	Human	NA
 EPI255384|A/Egypt/N04830/2009	A/Egypt/N04830/2009	avian_flu	EPI_ISL_74315	2009-05-29	Africa	Egypt	NA	NA	Human	NA
 EPI255382|A/Egypt/N04434/2010	A/Egypt/N04434/2010	avian_flu	EPI_ISL_74314	2010-03-31	Africa	Egypt	NA	NA	Human	NA
-EPI255379|A/Egypt/N03072/2010	A/Egypt/N03072/2010	avian_flu	EPI_ISL_74313	2010-03-07	Africa	Egypt	NA	NA	Human	NA
-EPI255377|A/Egypt/N03071/2010	A/Egypt/N03071/2010	avian_flu	EPI_ISL_74312	2010-03-03	Africa	Egypt	NA	NA	Human	NA
 EPI255375|A/Egypt/N02770/2010	A/Egypt/N02770/2010	avian_flu	EPI_ISL_74311	2010-02-27	Africa	Egypt	NA	NA	Human	NA
-EPI255373|A/Egypt/N02554/2010	A/Egypt/N02554/2010	avian_flu	EPI_ISL_74310	2010-02-23	Africa	Egypt	NA	NA	Human	NA
-EPI255371|A/Egypt/N02127/2010	A/Egypt/N02127/2010	avian_flu	EPI_ISL_74309	2010-02-13	Africa	Egypt	NA	NA	Human	NA
-EPI255369|A/Egypt/N02038/2010	A/Egypt/N02038/2010	avian_flu	EPI_ISL_74308	2010-02-15	Africa	Egypt	NA	NA	Human	NA
-EPI255367|A/Egypt/N01982/2010	A/Egypt/N01982/2010	avian_flu	EPI_ISL_74307	2010-02-12	Africa	Egypt	NA	NA	Human	NA
-EPI255365|A/Egypt/N01644/2010	A/Egypt/N01644/2010	avian_flu	EPI_ISL_74306	2010-02-07	Africa	Egypt	NA	NA	Human	NA
-EPI255363|A/Egypt/N01360/2010	A/Egypt/N01360/2010	avian_flu	EPI_ISL_74305	2010-02-02	Africa	Egypt	NA	NA	Human	NA
 EPI255361|A/Egypt/N00270/2010	A/Egypt/N00270/2010	avian_flu	EPI_ISL_74304	2010-01-12	Africa	Egypt	NA	NA	Human	NA
 EPI255359|A/Egypt/N00269/2010	A/Egypt/N00269/2010	avian_flu	EPI_ISL_74303	2010-01-11	Africa	Egypt	NA	NA	Human	NA
 EPI255357|A/Egypt/7021-NAMRU3/2006	A/Egypt/7021-NAMRU3/2006	avian_flu	EPI_ISL_74302	2006-05-16	Africa	Egypt	NA	NA	Human	NA
@@ -18743,12 +18466,9 @@ EPI764411|A/turtle dove/Guangdong/300/2005	A/turtle dove/Guangdong/300/2005	avia
 EPI760584|2013759080_237940_v1_4	A/poultry/Bangladesh/91392/2013	avian_flu	EPI_ISL_221822	2013-01-02	Asia	Bangladesh	NA	NA	Avian	NA
 EPI760130|A/peacock/Yunnan/3/2015	A/peacock/Yunnan/3/2015	avian_flu	EPI_ISL_221725	2015-06-02	Asia	China	NA	NA	Avian	NA
 EPI760123|A/peacock/Yunnan/1/2015	A/peacock/Yunnan/1/2015	avian_flu	EPI_ISL_221724	2015-06-02	Asia	China	NA	NA	Avian	NA
-EPI568231|A/gray-crowed crane/Thailand/VSMU-4-CBI/2005	A/gray-crowed crane/Thailand/VSMU-4-CBI/2005	avian_flu	EPI_ISL_173402	NA	Asia	Thailand	Chonburi	NA	Avian	Wild
 EPI568220|A/Openbill stork/Thailand/VSMU-16-AYA/2004	A/Openbill stork/Thailand/VSMU-16-AYA/2004	avian_flu	EPI_ISL_173401	NA	Asia	Thailand	Phra Nakhon Si Ayutthaya	NA	Avian	Wild
 EPI568215|A/Openbill stork/Thailand/VSMU-6-BKK/2004	A/Openbill stork/Thailand/VSMU-6-BKK/2004	avian_flu	EPI_ISL_173400	NA	Asia	Thailand	Bangkok	NA	Avian	Wild
 EPI568207|A/Silver Pheasant/Thailand/VSMU-1-CBI/2005	A/Silver Pheasant/Thailand/VSMU-1-CBI/2005	avian_flu	EPI_ISL_173399	NA	Asia	Thailand	Chonburi	NA	Avian	Wild
-NA	A/peaceful dove/Badung/BBVD-493/2007	avian_flu	EPI_ISL_140873	2007-08-27	Asia	Indonesia	NA	NA	Avian	NA
-NA	A/peaceful dove/Denpasar/BBVD-480/2007	avian_flu	EPI_ISL_140848	2007-08-23	Asia	Indonesia	NA	NA	Avian	NA
 EPI321744|A/muscovy duck/Vietnam/OIE-559/2011	A/muscovy duck/Vietnam/OIE-559/2011	avian_flu	EPI_ISL_91622	NA	Asia	Vietnam	NA	NA	Avian	NA
 EPI2782544|A/chicken/Austria/2786-1_21VIR11354/2021_HA	A/chicken/Austria/2786-1_21VIR11354/2021	avian_flu	EPI_ISL_18458073	2021-11-29	Europe	Austria	NA	NA	Chicken	NA
 EPI2782536|A/chicken/Austria/2782_21VIR11353/2021_HA	A/chicken/Austria/2782_21VIR11353/2021	avian_flu	EPI_ISL_18458072	2021-11-29	Europe	Austria	NA	NA	Chicken	NA
@@ -19016,61 +18736,12 @@ NA	A/chicken/Viet Nam/CT-437/2005	avian_flu	EPI_ISL_9306	NA	Asia	Vietnam	NA	NA	C
 EPI2162767|A/chicken/Bangladesh/49967/2021	A/chicken/Bangladesh/49967/2021	avian_flu	EPI_ISL_14885398	2021-09-18	Asia	Bangladesh	NA	NA	Gallus gallus	NA
 EPI1518236|A/Gallus gallus/Egypt/D2296H/2014	A/Gallus gallus/Egypt/D2296H/2014	avian_flu	EPI_ISL_370042	2014-11-11	Africa	Egypt	NA	NA	Gallus gallus	NA
 EPI1518235|A/Gallus gallus/Egypt/D2296E/2012	A/Gallus gallus/Egypt/D2296E/2012	avian_flu	EPI_ISL_370041	2012-12-20	Africa	Egypt	NA	NA	Gallus gallus	NA
-EPI953368|A/chicken/Egypt/F12505C/2016	A/chicken/Egypt/F12505C/2016	avian_flu	EPI_ISL_254827	2016-01-23	Africa	Egypt	NA	NA	Gallus gallus	NA
 EPI953354|A/chicken/Egypt/N12642E/2016	A/chicken/Egypt/N12642E/2016	avian_flu	EPI_ISL_254823	2016-05-08	Africa	Egypt	NA	NA	Gallus gallus	NA
 EPI953352|A/chicken/Egypt/N12643B/2016	A/chicken/Egypt/N12643B/2016	avian_flu	EPI_ISL_254821	2016-05-08	Africa	Egypt	NA	NA	Gallus gallus	NA
 EPI953372|A/chicken/Egypt/N12638D/2016	A/chicken/Egypt/N12638D/2016	avian_flu	EPI_ISL_254820	2016-05-08	Africa	Egypt	NA	NA	Gallus gallus	NA
-EPI953349|A/chicken/Egypt/F12505B/2016	A/chicken/Egypt/F12505B/2016	avian_flu	EPI_ISL_254819	2016-01-23	Africa	Egypt	NA	NA	Gallus gallus	NA
 EPI953346|A/chicken/Egypt/F12505E/2016	A/chicken/Egypt/F12505E/2016	avian_flu	EPI_ISL_254816	2016-01-23	Africa	Egypt	NA	NA	Gallus gallus	NA
 EPI953360|A/chicken/Egypt/N12640A/2016	A/chicken/Egypt/N12640A/2016	avian_flu	EPI_ISL_254815	2016-05-08	Africa	Egypt	NA	NA	Gallus gallus	NA
 EPI687187|A/chicken/Scotland/532/2016	A/chicken/Scotland/532/2016	avian_flu	EPI_ISL_205833	2016-01-09	Europe	United Kingdom	Fife	NA	Gallus gallus	Domestic
-NA	A/chicken/Jembrana/BBVD-298/2007	avian_flu	EPI_ISL_140872	2007-06-18	Asia	Indonesia	NA	NA	Gallus gallus	NA
-NA	A/chicken/Jembrana/BBVD-300/2006	avian_flu	EPI_ISL_140871	2006-08-04	Asia	Indonesia	NA	NA	Gallus gallus	NA
-NA	A/chicken/Badung/BBVD-532/2007	avian_flu	EPI_ISL_140870	2007-09-03	Asia	Indonesia	NA	NA	Gallus gallus	NA
-NA	A/chicken/Badung/BBVD-342/2007	avian_flu	EPI_ISL_140869	2007-07-11	Asia	Indonesia	NA	NA	Gallus gallus	NA
-NA	A/chicken/Badung/BBVD-328/2007	avian_flu	EPI_ISL_140868	2007-07-03	Asia	Indonesia	NA	NA	Gallus gallus	NA
-NA	A/chicken/Badung/BBVD-319ac/2007	avian_flu	EPI_ISL_140867	2007-06-25	Asia	Indonesia	NA	NA	Gallus gallus	NA
-NA	A/chicken/Badung/BBVD-302/2007	avian_flu	EPI_ISL_140866	2007-06-20	Asia	Indonesia	NA	NA	Gallus gallus	NA
-NA	A/chicken/Badung/BBVD-288/2007	avian_flu	EPI_ISL_140865	2007-06-13	Asia	Indonesia	NA	NA	Gallus gallus	NA
-NA	A/chicken/Badung/BBVD-277/2007	avian_flu	EPI_ISL_140864	2007-06-11	Asia	Indonesia	NA	NA	Gallus gallus	NA
-NA	A/chicken/Badung/BBVD-219/2007	avian_flu	EPI_ISL_140863	2007-05-23	Asia	Indonesia	NA	NA	Gallus gallus	NA
-NA	A/chicken/Badung/BBVD-216/2007	avian_flu	EPI_ISL_140862	2007-05-22	Asia	Indonesia	NA	NA	Gallus gallus	NA
-NA	A/chicken/Badung/BBVD-205/2007	avian_flu	EPI_ISL_140861	2007-05-15	Asia	Indonesia	NA	NA	Gallus gallus	NA
-NA	A/chicken/Badung/BBVD-175/2007	avian_flu	EPI_ISL_140860	2007-05-02	Asia	Indonesia	NA	NA	Gallus gallus	NA
-NA	A/chicken/Klungkung/BBVD-484/2007	avian_flu	EPI_ISL_140859	2007-08-23	Asia	Indonesia	NA	NA	Gallus gallus	NA
-NA	A/chicken/Klungkung/BBVD-455/2007	avian_flu	EPI_ISL_140858	2007-08-21	Asia	Indonesia	NA	NA	Gallus gallus	NA
-NA	A/chicken/Klungkung/BBVD-417/2007	avian_flu	EPI_ISL_140857	2007-08-06	Asia	Indonesia	NA	NA	Gallus gallus	NA
-NA	A/chicken/Klungkung/BBVD-279/2007	avian_flu	EPI_ISL_140856	2007-06-12	Asia	Indonesia	NA	NA	Gallus gallus	NA
-NA	A/chicken/Klungkung/BBVD-225/2007	avian_flu	EPI_ISL_140855	2007-05-24	Asia	Indonesia	NA	NA	Gallus gallus	NA
-NA	A/chicken/Jembrana/BBVD-298b/2007	avian_flu	EPI_ISL_140854	2007-06-18	Asia	Indonesia	NA	NA	Gallus gallus	NA
-NA	A/chicken/Jembrana/BBVD-273/2007	avian_flu	EPI_ISL_140853	2007-06-08	Asia	Indonesia	NA	NA	Gallus gallus	NA
-NA	A/chicken/Bangli/BBVD-575/2007	avian_flu	EPI_ISL_140852	2007-09-25	Asia	Indonesia	NA	NA	Gallus gallus	NA
-NA	A/chicken/Bangli/BBVD-563/2007	avian_flu	EPI_ISL_140851	2007-09-18	Asia	Indonesia	NA	NA	Gallus gallus	NA
-NA	A/chicken/Bangli/BBVD-562/2007	avian_flu	EPI_ISL_140850	2007-09-18	Asia	Indonesia	NA	NA	Gallus gallus	NA
-NA	A/chicken/Bangli/BBVD-555ab/2007	avian_flu	EPI_ISL_140849	2007-09-13	Asia	Indonesia	NA	NA	Gallus gallus	NA
-NA	A/chicken/Bangli/BBVD-245/2007	avian_flu	EPI_ISL_140846	2007-05-31	Asia	Indonesia	NA	NA	Gallus gallus	NA
-NA	A/chicken/Bangli/BBVD-343/2007	avian_flu	EPI_ISL_140845	2007-07-11	Asia	Indonesia	NA	NA	Gallus gallus	NA
-NA	A/chicken/Tabanan/BBVD-307/2007	avian_flu	EPI_ISL_140844	2007-06-21	Asia	Indonesia	NA	NA	Gallus gallus	NA
-NA	A/chicken/Tabanan/BBVD-461/2007	avian_flu	EPI_ISL_140843	2007-08-21	Asia	Indonesia	NA	NA	Gallus gallus	NA
-NA	A/chicken/Tabanan/BBVD-339/2007	avian_flu	EPI_ISL_140842	2007-07-10	Asia	Indonesia	NA	NA	Gallus gallus	NA
-NA	A/chicken/Tabanan/BBVD-142/2007	avian_flu	EPI_ISL_140841	2007-03-26	Asia	Indonesia	NA	NA	Gallus gallus	NA
-NA	A/chicken/Tabanan/BBVD-107/2007	avian_flu	EPI_ISL_140840	2007-03-09	Asia	Indonesia	NA	NA	Gallus gallus	NA
-NA	A/chicken/Ampenan/BBVD-282/2007	avian_flu	EPI_ISL_140839	NA	Asia	Indonesia	NA	NA	Gallus gallus	NA
-NA	A/chicken/Buleleng/BBVD-545b/2007	avian_flu	EPI_ISL_140838	2007-09-05	Asia	Indonesia	NA	NA	Gallus gallus	NA
-NA	A/chicken/Flores Timur/BBVD-256/2007	avian_flu	EPI_ISL_140837	2007-06-04	Asia	Indonesia	NA	NA	Gallus gallus	NA
-NA	A/chicken/Gianyar/BBVD-429/2007	avian_flu	EPI_ISL_140836	2007-08-15	Asia	Indonesia	NA	NA	Gallus gallus	NA
-NA	A/chicken/Gianyar/BBVD-687/2007	avian_flu	EPI_ISL_140835	2007-12-26	Asia	Indonesia	NA	NA	Gallus gallus	NA
-NA	A/chicken/Gianyar/BBVD-458/2007	avian_flu	EPI_ISL_140834	2007-08-21	Asia	Indonesia	NA	NA	Gallus gallus	NA
-NA	A/chicken/Denpasar/BBVD-560/2007	avian_flu	EPI_ISL_140833	2007-09-17	Asia	Indonesia	NA	NA	Gallus gallus	NA
-NA	A/chicken/Denpasar/BBVD-509/2007	avian_flu	EPI_ISL_140832	2007-08-28	Asia	Indonesia	NA	NA	Gallus gallus	NA
-NA	A/chicken/Denpasar/BBVD-494/2007	avian_flu	EPI_ISL_140831	2007-08-27	Asia	Indonesia	NA	NA	Gallus gallus	NA
-NA	A/chicken/Denpasar/BBVD-456/2007	avian_flu	EPI_ISL_140830	2007-08-21	Asia	Indonesia	NA	NA	Gallus gallus	NA
-NA	A/chicken/Denpasar/BBVD-435/2007	avian_flu	EPI_ISL_140829	2007-08-16	Asia	Indonesia	NA	NA	Gallus gallus	NA
-NA	A/chicken/Denpasar/BBVD-430/2007	avian_flu	EPI_ISL_140828	2007-08-15	Asia	Indonesia	NA	NA	Gallus gallus	NA
-NA	A/chicken/Denpasar/BBVD-331/2007	avian_flu	EPI_ISL_140827	2007-07-05	Asia	Indonesia	NA	NA	Gallus gallus	NA
-NA	A/chicken/Denpasar/BBVD-291/2007	avian_flu	EPI_ISL_140826	2007-06-14	Asia	Indonesia	NA	NA	Gallus gallus	NA
-NA	A/chicken/Denpasar/BBVD-182/2007	avian_flu	EPI_ISL_140825	2007-05-29	Asia	Indonesia	NA	NA	Gallus gallus	NA
-NA	A/chicken/Denpasar/BBVD-145/2007	avian_flu	EPI_ISL_140824	2007-03-27	Asia	Indonesia	NA	NA	Gallus gallus	NA
 NA	A/chicken/Bantaeng/BBVM-1/2008	avian_flu	EPI_ISL_139838	2008-10-07	Asia	Indonesia	NA	NA	Gallus gallus	NA
 NA	A/chicken/Maros/BBVM-3/2008	avian_flu	EPI_ISL_139837	2008-06-27	Asia	Indonesia	NA	NA	Gallus gallus	NA
 NA	A/chicken/Maros/BBVM-1/2008	avian_flu	EPI_ISL_139836	2008-06-26	Asia	Indonesia	NA	NA	Gallus gallus	NA
@@ -19250,7 +18921,6 @@ EPI321522|A/duck/Bantul/BBVW-387-23310/2007	A/duck/Bantul/BBVW-387-23310/2007	av
 EPI321520|A/duck/Bantul/BBVW-358-24381/2007	A/duck/Bantul/BBVW-358-24381/2007	avian_flu	EPI_ISL_91517	2007-06-19	Asia	Indonesia	NA	NA	Duck	NA
 EPI321519|A/duck/Bantul/BBVW-224-24466/2007	A/duck/Bantul/BBVW-224-24466/2007	avian_flu	EPI_ISL_91516	2007-05-05	Asia	Indonesia	NA	NA	Duck	NA
 EPI321517|A/duck/Bantul/BBVW-1005-24442/2007	A/duck/Bantul/BBVW-1005-24442/2007	avian_flu	EPI_ISL_91515	2007-12-17	Asia	Indonesia	NA	NA	Duck	NA
-EPI321516|A/duck/Bangli/BBVD-246/2007	A/duck/Bangli/BBVD-246/2007	avian_flu	EPI_ISL_91514	2007-05-31	Asia	Indonesia	NA	NA	Duck	NA
 EPI320685|A/Muscovy duck/Vietnam/18153/2009	A/Muscovy duck/Vietnam/18153/2009	avian_flu	EPI_ISL_91148	2009-04-08	Asia	Vietnam	NA	NA	Duck	NA
 EPI320684|A/Muscovy duck/Vietnam/18152/2009	A/Muscovy duck/Vietnam/18152/2009	avian_flu	EPI_ISL_91147	2009-04-08	Asia	Vietnam	NA	NA	Duck	NA
 EPI320682|A/Muscovy duck/Vietnam/18151/2009	A/Muscovy duck/Vietnam/18151/2009	avian_flu	EPI_ISL_91146	2009-04-08	Asia	Vietnam	NA	NA	Duck	NA
@@ -19384,7 +19054,6 @@ EPI107743|A/goose/Guangxi/4513/2005	A/goose/Guangxi/4513/2005	avian_flu	EPI_ISL_
 EPI107739|A/goose/Guangxi/4289/2005	A/goose/Guangxi/4289/2005	avian_flu	EPI_ISL_10679	NA	Asia	China	Guangxi Zhuang Autonomous Region	NA	Goose	NA
 EPI107891|A/goose/Yunnan/5539/2005	A/goose/Yunnan/5539/2005	avian_flu	EPI_ISL_10678	NA	Asia	China	Yunnan Province	NA	Goose	NA
 EPI107903|A/goose/Yunnan/6368/2005	A/goose/Yunnan/6368/2005	avian_flu	EPI_ISL_10675	NA	Asia	China	Yunnan Province	NA	Goose	NA
-EPI107811|A/goose/Guiyang/337/2006	A/goose/Guiyang/337/2006	avian_flu	EPI_ISL_10667	NA	Asia	China	NA	NA	Goose	NA
 EPI106410|A/goose/Crimea/615/05	A/goose/Crimea/615/05	avian_flu	EPI_ISL_10445	NA	Europe	Ukraine	NA	NA	Goose	NA
 EPI106235|A/goose/Guangzhou/471/2006	A/goose/Guangzhou/471/2006	avian_flu	EPI_ISL_10411	NA	Asia	China	Guangdong Province	Guangzhou	Goose	NA
 EPI106133|A/goose/Huadong/220/2004	A/goose/Huadong/220/2004	avian_flu	EPI_ISL_10395	NA	Asia	China	NA	NA	Goose	NA
@@ -19444,7 +19113,6 @@ EPI573268|AR238-FAOSD177NLQP_HA	A/Turkey/Egypt/AR238-SD177NLQP/2014	avian_flu	EP
 EPI573252|AR235-FAOS240NLQP_HA	A/Turkey/Egypt/AR235-S240NLQP/2014	avian_flu	EPI_ISL_174406	2014-10-31	Africa	Egypt	NA	NA	Turkey	NA
 EPI359887|A/turkey/Korea/DDC518/2011	A/turkey/Korea/DDC518/2011	avian_flu	EPI_ISL_108423	NA	Asia	Korea, Republic of	NA	NA	Turkey	NA
 EPI169514|HA_3489-70	A/turkey/Saudi Arabia/3489-70VIR08/2007	avian_flu	EPI_ISL_26362	NA	Asia	Saudi Arabia	NA	NA	Turkey	NA
-NA	A/turkey/France/06222/2006	avian_flu	EPI_ISL_26343	2006-02-23	Europe	France	Rhone-Alpes	NA	Turkey	NA
 EPI106177|A/Turkey/Egypt/5613NAMRU3-T/2006	A/Turkey/Egypt/5613NAMRU3-T/2006	avian_flu	EPI_ISL_10400	NA	Africa	Egypt	NA	NA	Turkey	NA
 EPI116418|A/turkey/Israel/446/2006	A/turkey/Israel/446/2006	avian_flu	EPI_ISL_10372	NA	Asia	Israel	NA	NA	Turkey	NA
 EPI116410|A/turkey/Israel/345/2006	A/turkey/Israel/345/2006	avian_flu	EPI_ISL_10369	NA	Asia	Israel	NA	NA	Turkey	NA
@@ -19542,17 +19210,8 @@ EPI448247|2012705949_214206_v1_4	A/environment/Bangladesh/1011/2011	avian_flu	EP
 EPI448239|2012705927_214205_v1_4	A/Environment/Bangladesh/1018/2011	avian_flu	EPI_ISL_141285	2011-09-29	Asia	Bangladesh	NA	NA	Environment	NA
 EPI448119|2012705555_208795_v1_4	A/environment/Bangladesh/1017/2011	avian_flu	EPI_ISL_141270	2011-05-29	Asia	Bangladesh	NA	NA	Environment	NA
 EPI100494|A/Environment/Qinghai/31/2005	A/Environment/Qinghai/31/2005	avian_flu	EPI_ISL_9941	NA	Asia	China	Qinghai Province	NA	Environment	NA
-NA	A/mallard/Italy/3401/2005	avian_flu	EPI_ISL_141050	NA	Europe	Italy	NA	NA	Laboratory derived	NA
-NA	A/mallard/Italy/3401/2005	avian_flu	EPI_ISL_141049	NA	Europe	Italy	NA	NA	Laboratory derived	NA
-NA	A/mallard/Italy/3401/2005	avian_flu	EPI_ISL_141048	NA	Europe	Italy	NA	NA	Laboratory derived	NA
-NA	A/mallard/Italy/3401/2005	avian_flu	EPI_ISL_141047	NA	Europe	Italy	NA	NA	Laboratory derived	NA
-NA	A/mallard/Italy/3401/2005	avian_flu	EPI_ISL_141046	NA	Europe	Italy	NA	NA	Laboratory derived	NA
-NA	A/mallard/Italy/3401/2005	avian_flu	EPI_ISL_141045	NA	Europe	Italy	NA	NA	Laboratory derived	NA
-EPI447402|A/mallard/Italy/3401/2005	A/mallard/Italy/3401/2005	avian_flu	EPI_ISL_141044	NA	Europe	Italy	NA	NA	Laboratory derived	NA
-EPI447381|A/mallard/Italy/3401/2005, EPI447388|A/mallard/Italy/3401/2005	A/mallard/Italy/3401/2005	avian_flu	EPI_ISL_141042	NA	Europe	Italy	NA	NA	Laboratory derived	NA
 EPI266943|A/whooper swan/Mongolia/3/2005	A/whooper swan/Mongolia/3/2005	avian_flu	EPI_ISL_76070	NA	North America	United States	NA	NA	Laboratory derived	NA
 EPI1435662|A/Nepal/19FL1997/2019	A/Nepal/19FL1997/2019	avian_flu	EPI_ISL_354656	2019-03-25	Asia	Nepal	NA	NA	Human	NA
-EPI1435654|A/Nepal/19FL1997/2019	A/Nepal/19FL1997/2019	avian_flu	EPI_ISL_354655	2019-03-25	Asia	Nepal	NA	NA	Human	NA
 NA	A/Vietnam/31604-1/2009	avian_flu	EPI_ISL_174488	2009-02-05	Asia	Vietnam	NA	NA	Human	NA
 EPI573556|A/Vietnam/36285/2010	A/Vietnam/36285/2010	avian_flu	EPI_ISL_174487	2010-04-02	Asia	Vietnam	NA	NA	Human	NA
 NA	A/Vietnam/UT36285/2010	avian_flu	EPI_ISL_174485	2010-04-02	Asia	Vietnam	NA	NA	Human	NA
@@ -19579,9 +19238,6 @@ EPI104930|A/Vietnam/CL105/2005	A/Vietnam/CL105/2005	avian_flu	EPI_ISL_10245	NA	A
 EPI103091|A/Egypt/2782-NAMRU3/2006	A/Egypt/2782-NAMRU3/2006	avian_flu	EPI_ISL_10143	NA	Africa	Egypt	NA	NA	Human	NA
 EPI102992|A/human/Iraq/207-NAMRU3/2006	A/human/Iraq/207-NAMRU3/2006	avian_flu	EPI_ISL_10130	NA	Asia	Iraq	NA	NA	Human	NA
 EPI101923|A/Thailand/NK165/2005	A/Thailand/NK165/2005	avian_flu	EPI_ISL_10061	NA	Asia	Thailand	NA	NA	Human	NA
-EPI275462|A/Guangxi/1/2005	A/Guangxi/1/2005	avian_flu	EPI_ISL_10060	NA	Asia	China	Guangxi Zhuang Autonomous Region	NA	Human	NA
-EPI275386|A/Anhui/2/2005, EPI101919|A/Anhui/2/2005	A/Anhui/2/2005	avian_flu	EPI_ISL_10059	NA	Asia	China	Anhui Province	NA	Human	NA
-EPI275378|A/Anhui/1/2005, EPI101917|A/Anhui/1/2005	A/Anhui/1/2005	avian_flu	EPI_ISL_10058	2005-11-08	Asia	China	Anhui Province	NA	Human	NA
 EPI101747|A/Thailand/676/2005	A/Thailand/676/2005	avian_flu	EPI_ISL_10049	NA	Asia	Thailand	NA	NA	Human	NA
 EPI2540784|H543_4	A/duck/Korea/H543/2021	avian_flu	EPI_ISL_17606865	2021-11-14	Asia	Korea, Republic of	CB	NA	Avian	NA
 EPI2540560|H649_4	A/duck/Korea/H649/2021	avian_flu	EPI_ISL_17606837	2021-12-29	Asia	Korea, Republic of	JN	NA	Avian	NA
@@ -19643,7 +19299,6 @@ EPI359891|A/wild bird/Korea/IS18/2011	A/wild bird/Korea/IS18/2011	avian_flu	EPI_
 EPI359862|A/eurasian eagle owl/Korea/Q182/2011	A/eurasian eagle owl/Korea/Q182/2011	avian_flu	EPI_ISL_108416	NA	Asia	Korea, Republic of	NA	NA	Avian	NA
 EPI359861|A/eurasian eagle owl/Korea/Q178/2011	A/eurasian eagle owl/Korea/Q178/2011	avian_flu	EPI_ISL_108414	NA	Asia	Korea, Republic of	NA	NA	Avian	NA
 EPI359881|A/eurasian eagle owl/Korea/Q196/2011	A/eurasian eagle owl/Korea/Q196/2011	avian_flu	EPI_ISL_108413	NA	Asia	Korea, Republic of	NA	NA	Avian	NA
-EPI3467387|A/chicken/Egypt/F12505B/2016_HA	A/chicken/Egypt/F12505B/2016	avian_flu	EPI_ISL_19293714	NA	Africa	Egypt	NA	NA	Chicken	NA
 EPI2885624|A/chicken/Ehime/21A4C/2021(ha), EPI2885625|A/chicken/Ehime/21A4C/2021(ha)	A/chicken/Ehime/21A4C/2021	avian_flu	EPI_ISL_18720789	2021-12-31	Asia	Japan	Ehime	NA	Chicken	NA
 EPI2885610|A/chicken/Ehime/21A11T/2021(ha)	A/chicken/Ehime/21A11T/2021	avian_flu	EPI_ISL_18720787	2021-12-31	Asia	Japan	Ehime	NA	Chicken	NA
 EPI2885376|A/chicken/Ehime/21A4T/2021(ha)	A/chicken/Ehime/21A4T/2021	avian_flu	EPI_ISL_18720768	2021-12-31	Asia	Japan	Ehime	NA	Chicken	NA
@@ -19742,7 +19397,6 @@ EPI620557|A/chicken/Jembrana/07A/2005	A/chicken/Jembrana/07A/2005	avian_flu	EPI_
 EPI620556|A/chicken/Bangli/06/2005	A/chicken/Bangli/06/2005	avian_flu	EPI_ISL_190500	2005-10-20	Asia	Indonesia	NA	NA	Chicken	NA
 EPI573337|1540S_HA	A/chicken/Egypt/1540S/2015	avian_flu	EPI_ISL_174439	2015-01-11	Africa	Egypt	NA	NA	Chicken	NA
 EPI573334|141_HA	A/chicken/Egypt/141/2014	avian_flu	EPI_ISL_174437	2014-11-03	Africa	Egypt	NA	NA	Chicken	NA
-EPI573333|1427AF_HA	A/chicken/Egypt/1427AF/2014	avian_flu	EPI_ISL_174436	2014-09-03	Africa	Egypt	NA	NA	Chicken	NA
 EPI573330|1476CA_HA	A/chicken/Egypt/1476CA/2014	avian_flu	EPI_ISL_174434	2014-10-14	Africa	Egypt	NA	NA	Chicken	NA
 EPI573329|14140CA_HA	A/chicken/Egypt/14140CA/2014	avian_flu	EPI_ISL_174433	2014-12-05	Africa	Egypt	NA	NA	Chicken	NA
 EPI573328|14168CA_HA	A/chicken/Egypt/14168CA/2014	avian_flu	EPI_ISL_174432	2014-12-16	Africa	Egypt	NA	NA	Chicken	NA
@@ -19825,7 +19479,6 @@ EPI106412|A/chicken/Krasnodar/199/06	A/chicken/Krasnodar/199/06	avian_flu	EPI_IS
 EPI106408|A/chicken/Tambov/570-2/05	A/chicken/Tambov/570-2/05	avian_flu	EPI_ISL_10444	NA	Europe	Russian Federation	Tambov Oblast	NA	Chicken	NA
 EPI106406|A/chicken/Adygea/203/06	A/chicken/Adygea/203/06	avian_flu	EPI_ISL_10443	NA	Europe	Russian Federation	Republic of Adygea	NA	Chicken	NA
 EPI106352|A/chicken/Sudan/1784/2006	A/chicken/Sudan/1784/2006	avian_flu	EPI_ISL_10437	NA	Africa	Sudan	NA	NA	Chicken	NA
-EPI106197|A/chicken/Niger/2130-7/2006	A/chicken/Niger/2130-7/2006	avian_flu	EPI_ISL_10408	NA	Africa	Niger	NA	NA	Chicken	NA
 EPI106195|A/chicken/Niger/2130-8/2006	A/chicken/Niger/2130-8/2006	avian_flu	EPI_ISL_10407	NA	Africa	Niger	NA	NA	Chicken	NA
 EPI106175|A/Chicken/Egypt/5612NAMRU3-S/2006	A/Chicken/Egypt/5612NAMRU3-S/2006	avian_flu	EPI_ISL_10399	NA	Africa	Egypt	NA	NA	Chicken	NA
 EPI106173|A/Chicken/Egypt/5611NAMRU3-AN/2006	A/Chicken/Egypt/5611NAMRU3-AN/2006	avian_flu	EPI_ISL_10398	NA	Africa	Egypt	NA	NA	Chicken	NA
@@ -19838,7 +19491,6 @@ EPI105696|A/chicken/Ivory_Coast/1787/2006	A/chicken/Ivory Coast/1787/2006	avian_
 EPI105596|A/chicken/Crimea/08/2005	A/chicken/Crimea/08/2005	avian_flu	EPI_ISL_10340	NA	Europe	Ukraine	NA	NA	Chicken	NA
 EPI105588|A/chicken/Crimea/04/2005	A/chicken/Crimea/04/2005	avian_flu	EPI_ISL_10339	NA	Europe	Ukraine	NA	NA	Chicken	NA
 EPI105579|A/chicken/Denpasar/02/2005	A/chicken/Denpasar/02/2005	avian_flu	EPI_ISL_10335	NA	Asia	Indonesia	Bali	Denpasar	Chicken	NA
-EPI154538|A/chicken/Denpasar/01/2004	A/chicken/Denpasar/01/2004	avian_flu	EPI_ISL_10334	NA	Asia	Indonesia	Bali	Denpasar	Chicken	NA
 EPI105404|A/chicken/Zhejiang/24/2005	A/chicken/Zhejiang/24/2005	avian_flu	EPI_ISL_10302	NA	Asia	China	Zhejiang Province	NA	Chicken	NA
 EPI104914|A/chicken/Vietnam/132/2004	A/chicken/Vietnam/132/2004	avian_flu	EPI_ISL_10242	NA	Asia	Vietnam	NA	NA	Chicken	NA
 EPI104906|A/chicken/Vietnam/134/2004	A/chicken/Vietnam/134/2004	avian_flu	EPI_ISL_10239	NA	Asia	Vietnam	NA	NA	Chicken	NA
@@ -19890,14 +19542,12 @@ EPI100438|A/chicken/Guangxi/2448/2004	A/chicken/Guangxi/2448/2004	avian_flu	EPI_
 EPI100436|A/chicken/Guangxi/2439/2004	A/chicken/Guangxi/2439/2004	avian_flu	EPI_ISL_9912	NA	Asia	China	Guangxi Zhuang Autonomous Region	NA	Chicken	NA
 EPI100402|A/chicken/Fujian/1042/2005	A/chicken/Fujian/1042/2005	avian_flu	EPI_ISL_9895	NA	Asia	China	Fujian Province	NA	Chicken	NA
 EPI99999|A/chicken/Tula/10/2005	A/chicken/Tula/10/2005	avian_flu	EPI_ISL_9876	NA	Europe	Russian Federation	Tula Oblast	NA	Chicken	NA
-EPI1985904|2022-wk06-07_HA_H5	A/chicken/Netherlands/21037287-006010/2021	avian_flu	EPI_ISL_9856775	2021-10-25	Europe	Netherlands	Provincie Flevoland	NA	Gallus gallus	NA
 EPI1575298|A/chicken/Egypt/B13825A/2017	A/chicken/Egypt/B13825A/2017	avian_flu	EPI_ISL_387142	2017-03-07	Africa	Egypt	NA	NA	Gallus gallus	NA
 EPI869846|A/chicken/Bangladesh/PAI327/2011	A/chicken/Bangladesh/PAI327/2011	avian_flu	EPI_ISL_240029	2011-03-17	Asia	Bangladesh	NA	NA	Gallus gallus	Domestic
 EPI620964|A/chicken/Egypt/1063/2010	A/chicken/Egypt/1063/2010	avian_flu	EPI_ISL_190643	NA	Africa	Egypt	NA	NA	Gallus gallus	NA
 EPI621105|A/chicken/WestJava/SMI-PAT/2006	A/chicken/WestJava/SMI-PAT/2006	avian_flu	EPI_ISL_190642	NA	Asia	Indonesia	NA	NA	Gallus gallus	NA
 EPI620926|A/chicken/Egypt/06553-NLQP/2006	A/chicken/Egypt/06553-NLQP/2006	avian_flu	EPI_ISL_190640	NA	Africa	Egypt	NA	NA	Gallus gallus	NA
 EPI620898|A/chicken/Egypt/102d/2010	A/chicken/Egypt/102d/2010	avian_flu	EPI_ISL_190639	NA	Africa	Egypt	NA	NA	Gallus gallus	NA
-EPI620928|A/chicken/Egypt/096L-NLQP/2009	A/chicken/Egypt/096L-NLQP/2009	avian_flu	EPI_ISL_190636	NA	Africa	Egypt	NA	NA	Gallus gallus	NA
 EPI620940|A/chicken/Egypt/07118-NLQP/2007	A/chicken/Egypt/07118-NLQP/2007	avian_flu	EPI_ISL_190634	NA	Africa	Egypt	NA	NA	Gallus gallus	NA
 EPI620988|A/chicken/Egypt/0813-NLQP/2008	A/chicken/Egypt/0813-NLQP/2008	avian_flu	EPI_ISL_190633	NA	Africa	Egypt	NA	NA	Gallus gallus	NA
 EPI620966|A/chicken/Vietnam/NCVD-421/2010	A/chicken/Vietnam/NCVD-421/2010	avian_flu	EPI_ISL_190632	NA	Asia	Vietnam	NA	NA	Gallus gallus	NA
@@ -19905,8 +19555,6 @@ EPI620919|A/chicken/Vietnam/NCVD-185/2008	A/chicken/Vietnam/NCVD-185/2008	avian_
 EPI620828|A/chicken/Vietnam/NCVD-398/2010	A/chicken/Vietnam/NCVD-398/2010	avian_flu	EPI_ISL_190629	NA	Asia	Vietnam	NA	NA	Gallus gallus	NA
 EPI620819|A/chicken/West Java/TJA/2008	A/chicken/West Java/TJA/2008	avian_flu	EPI_ISL_190625	NA	Asia	Indonesia	NA	NA	Gallus gallus	NA
 EPI622514|A/chicken/Vietnam/NCVD-117/2008	A/chicken/Vietnam/NCVD-117/2008	avian_flu	EPI_ISL_190621	NA	Asia	Vietnam	NA	NA	Gallus gallus	NA
-EPI620937|A/chicken/Vietnam/NCVD-675/2011	A/chicken/Vietnam/NCVD-675/2011	avian_flu	EPI_ISL_190620	NA	Asia	Vietnam	NA	NA	Gallus gallus	NA
-EPI620809|A/chicken/Garut/BBVW-223/2007	A/chicken/Garut/BBVW-223/2007	avian_flu	EPI_ISL_190619	NA	Asia	Indonesia	NA	NA	Gallus gallus	NA
 EPI620908|A/chicken/Pekalongan/BBVW/2007	A/chicken/Pekalongan/BBVW/2007	avian_flu	EPI_ISL_190617	NA	Asia	Indonesia	NA	NA	Gallus gallus	NA
 EPI620916|A/chicken/WestJava/TASIKO B/2006	A/chicken/WestJava/TASIKO B/2006	avian_flu	EPI_ISL_190614	NA	Asia	Indonesia	NA	NA	Gallus gallus	NA
 NA	A/chicken/Cambodia/CMB07.71LC4/2007	avian_flu	EPI_ISL_141073	2007-04-09	Asia	Cambodia	NA	NA	Gallus gallus	NA
@@ -19928,7 +19576,6 @@ EPI2387050|A/Duck/Bangladesh/200O-DUC-S3-14/2017	A/Duck/Bangladesh/200O-DUC-S3-1
 EPI2387046|A/Duck/Bangladesh/200O-DUCS1-1/2017	A/Duck/Bangladesh/200O-DUCS1-1/2017	avian_flu	EPI_ISL_16868961	2017-12-18	Asia	Bangladesh	NA	NA	Duck	NA
 EPI2387038|A/Duck/Bangladesh/200O-DUC-S1-4/2018	A/Duck/Bangladesh/200O-DUC-S1-4/2018	avian_flu	EPI_ISL_16868931	2018-03-06	Asia	Bangladesh	NA	NA	Duck	NA
 EPI2387037|A/Duck/Bangladesh/200O-DUC-S1-2/2018	A/Duck/Bangladesh/200O-DUC-S1-2/2018	avian_flu	EPI_ISL_16868930	2018-07-16	Asia	Bangladesh	NA	NA	Duck	NA
-NA	A/Duck/Bangladesh/200O-DUC-S3-14/2017	avian_flu	EPI_ISL_16868929	2017-07-30	Asia	Bangladesh	NA	NA	Duck	NA
 EPI2387042|A/Duck/Bangladesh/200O-DUC-S3-15/2018	A/Duck/Bangladesh/200O-DUC-S3-15/2018	avian_flu	EPI_ISL_16868927	2018-01-16	Asia	Bangladesh	NA	NA	Duck	NA
 EPI2387039|A/Duck/Bangladesh/200O-DUC-S2-8/2018	A/Duck/Bangladesh/200O-DUC-S2-8/2018	avian_flu	EPI_ISL_16868925	2018-02-18	Asia	Bangladesh	NA	NA	Duck	NA
 NA	A/Duck/Bangladesh/200O-DUC-S1-1/2017	avian_flu	EPI_ISL_16868923	2017-12-18	Asia	Bangladesh	NA	NA	Duck	NA
@@ -19955,7 +19602,6 @@ EPI620555|A/duck/Karangasem/04/2005	A/duck/Karangasem/04/2005	avian_flu	EPI_ISL_
 NA	A/duck/Bangladesh/Gouripure-12/2013	avian_flu	EPI_ISL_190490	NA	Asia	Bangladesh	NA	NA	Duck	NA
 EPI615189|A/duck/TienGiang/1/2013	A/duck/TienGiang/1/2013	avian_flu	EPI_ISL_190090	2013-11-01	Asia	Vietnam	NA	NA	Duck	NA
 EPI573335|14227FAOS_HA	A/duck/Egypt/14227FAOS/2014	avian_flu	EPI_ISL_174438	2014-11-04	Africa	Egypt	NA	NA	Duck	NA
-EPI573332|14154FAOS_HA	A/duck/Egypt/14154FAOS/2014	avian_flu	EPI_ISL_174435	2014-06-25	Africa	Egypt	NA	NA	Duck	NA
 EPI573324|1560S_HA	A/duck/Egypt/1560S/2015	avian_flu	EPI_ISL_174430	2015-01-18	Africa	Egypt	NA	NA	Duck	NA
 EPI573323|144_HA	A/duck/Egypt/144/2014	avian_flu	EPI_ISL_174429	2014-12-04	Africa	Egypt	NA	NA	Duck	NA
 EPI573316|1427SL_HA	A/duck/Egypt/1427SL/2014	avian_flu	EPI_ISL_174423	2014-12-14	Africa	Egypt	NA	NA	Duck	NA
@@ -20029,8 +19675,6 @@ EPI259570|A/duck/Egypt/D3Li12/2007	A/duck/Egypt/D3Li12/2007	avian_flu	EPI_ISL_75
 EPI259569|A/duck/Egypt/D3Lu6/2007	A/duck/Egypt/D3Lu6/2007	avian_flu	EPI_ISL_75423	NA	Africa	Egypt	NA	NA	Duck	NA
 EPI259568|A/duck/Egypt/D2Li234/2007	A/duck/Egypt/D2Li234/2007	avian_flu	EPI_ISL_75422	NA	Africa	Egypt	NA	NA	Duck	NA
 EPI259567|A/duck/Egypt/D2Br210/2007	A/duck/Egypt/D2Br210/2007	avian_flu	EPI_ISL_75421	NA	Africa	Egypt	NA	NA	Duck	NA
-NA	A/common pochard/France/06167/2006	avian_flu	EPI_ISL_26341	2006-02-16	Europe	France	Rhone-Alpes	NA	Duck	NA
-NA	A/duck/France/05066b/2005	avian_flu	EPI_ISL_26263	2005-02-08	Europe	France	Region Pays de la Loire	NA	Duck	NA
 EPI106418|A/wild_duck/Omsk/103-01/05	A/wild duck/Omsk/103-01/05	avian_flu	EPI_ISL_10449	NA	Europe	Russian Federation	Omsk Oblast	NA	Duck	NA
 EPI106334|A/duck/Tuva/01/2006	A/duck/Tuva/01/2006	avian_flu	EPI_ISL_10436	NA	Europe	Russian Federation	Tyva Republic	NA	Duck	NA
 EPI154539|A/duck/Badung-Bali/05/2005	A/duck/Badung-Bali/05/2005	avian_flu	EPI_ISL_10338	NA	Asia	Indonesia	NA	NA	Duck	NA
@@ -20101,8 +19745,6 @@ EPI620976|A/duck/Vietnam Hau Giang/NCVD-12/2007	A/duck/Vietnam Hau Giang/NCVD-12
 EPI620817|A/duck/Vietnam/NCVD-672/2011	A/duck/Vietnam/NCVD-672/2011	avian_flu	EPI_ISL_190624	NA	Asia	Vietnam	NA	NA	Anas platyrhynchos	NA
 EPI620814|A/duck/Vietnam SonLa/NCVD-33/2007	A/duck/Vietnam SonLa/NCVD-33/2007	avian_flu	EPI_ISL_190622	NA	Asia	Vietnam	NA	NA	Anas platyrhynchos	NA
 EPI620813|A/duck/Vietnam NamDinh/NCVD-88/2007	A/duck/Vietnam NamDinh/NCVD-88/2007	avian_flu	EPI_ISL_190615	NA	Asia	Vietnam	NA	NA	Anas platyrhynchos	NA
-NA	A/mallard/Italy/3401/2005	avian_flu	EPI_ISL_141043	2005-09-19	Europe	Italy	NA	NA	Anas platyrhynchos	NA
-EPI447374|A/mallard/Italy/3401/2005	A/mallard/Italy/3401/2005	avian_flu	EPI_ISL_141041	2005-09-19	Europe	Italy	NA	NA	Anas platyrhynchos	NA
 EPI259563|A/Hong Kong/213-DkPass/2003	A/Hong Kong/213-DkPass/2003	avian_flu	EPI_ISL_75420	NA	Asia	Hong Kong (SAR)	NA	NA	Anas platyrhynchos	NA
 EPI104858|A/mallard/Vietnam/3/2003	A/mallard/Vietnam/3/2003	avian_flu	EPI_ISL_10216	NA	Asia	Vietnam	NA	NA	Anas platyrhynchos	NA
 EPI104838|A/mallard/Vietnam/21/2003	A/mallard/Vietnam/21/2003	avian_flu	EPI_ISL_10206	NA	Asia	Vietnam	NA	NA	Anas platyrhynchos	NA
@@ -20148,7 +19790,6 @@ EPI107893|A/duck/Yunnan/5820/2005	A/duck/Yunnan/5820/2005	avian_flu	EPI_ISL_1067
 EPI107887|A/duck/Yunnan/5251/2005	A/duck/Yunnan/5251/2005	avian_flu	EPI_ISL_10673	NA	Asia	China	Yunnan Province	NA	Anas sp.	NA
 EPI107763|A/duck/Guangxi/89/2006	A/duck/Guangxi/89/2006	avian_flu	EPI_ISL_10669	NA	Asia	China	Guangxi Zhuang Autonomous Region	NA	Anas sp.	NA
 EPI107787|A/duck/Guiyang/2231/2005	A/duck/Guiyang/2231/2005	avian_flu	EPI_ISL_10666	NA	Asia	China	NA	NA	Anas sp.	NA
-EPI106243|A/duck/Laos/3295/2006	A/duck/Laos/3295/2006	avian_flu	EPI_ISL_10413	NA	Asia	Lao, People's Democratic Republic	NA	NA	Anas sp.	NA
 EPI105583|A/duck/Buleleng-Bali/04/2005	A/duck/Buleleng-Bali/04/2005	avian_flu	EPI_ISL_10337	NA	Asia	Indonesia	NA	NA	Anas sp.	NA
 EPI105581|A/duck/Jembrana-Bali/03/2005	A/duck/Jembrana-Bali/03/2005	avian_flu	EPI_ISL_10336	NA	Asia	Indonesia	NA	NA	Anas sp.	NA
 EPI359882|A/eurasian sparrowhawk/Korea/Q94/2011	A/eurasian sparrowhawk/Korea/Q94/2011	avian_flu	EPI_ISL_108422	NA	Asia	Korea, Republic of	NA	NA	Accipiter nisus	NA
@@ -20313,7 +19954,6 @@ EPI171539|A/bar-headed_goose/Qinghai/1/2008	A/bar-headed goose/Qinghai/1/2008	av
 EPI171538|A/bar-headed_goose/Qinghai/13/2007	A/bar-headed goose/Qinghai/13/2007	avian_flu	EPI_ISL_27745	2007-09-22	Asia	China	Qinghai Province	NA	Anser indicus	NA
 EPI171532|A/bar-headed_goose/Qinghai/7/2007	A/bar-headed goose/Qinghai/7/2007	avian_flu	EPI_ISL_27739	2007-06-25	Asia	China	Qinghai Province	NA	Anser indicus	NA
 EPI171531|A/bar-headed_goose/Qinghai/5/2007	A/bar-headed goose/Qinghai/5/2007	avian_flu	EPI_ISL_27738	2007-06-19	Asia	China	Qinghai Province	NA	Anser indicus	NA
-EPI171528|A/bar-headed_goose/Qinghai/2/2007	A/bar-headed goose/Qinghai/2/2007	avian_flu	EPI_ISL_27735	2007-05-10	Asia	China	Qinghai Province	NA	Anser indicus	NA
 EPI171527|A/bar-headed_goose/Qinghai/11/2006	A/bar-headed goose/Qinghai/11/2006	avian_flu	EPI_ISL_27734	2006-08-18	Asia	China	Qinghai Province	NA	Anser indicus	NA
 EPI171525|A/bar-headed_goose/Qinghai/9/2006	A/bar-headed goose/Qinghai/9/2006	avian_flu	EPI_ISL_27732	2006-07-18	Asia	China	Qinghai Province	NA	Anser indicus	NA
 EPI171524|A/bar-headed_goose/Qinghai/8/2006	A/bar-headed goose/Qinghai/8/2006	avian_flu	EPI_ISL_27731	2006-07-18	Asia	China	Qinghai Province	NA	Anser indicus	NA
@@ -20353,11 +19993,6 @@ EPI1929979|2021-wk47-04_HA_H5	A/mute swan/Netherlands/21038142-001/2021	avian_fl
 EPI171612|A/Cygnus_olor/Germany/R1372/2007	A/Cygnus olor/Germany/R1372/2007	avian_flu	EPI_ISL_27764	NA	Europe	Germany	NA	NA	Cygnus olor	NA
 EPI114601|A/mute_swan/Bavaria/12/2006	A/mute swan/Bavaria/12/2006	avian_flu	EPI_ISL_11350	NA	Europe	Germany	Bavaria	NA	Cygnus olor	NA
 NA	A/turkey/Karo/94-09-1/2009	avian_flu	EPI_ISL_305642	NA	Asia	Indonesia	NA	NA	Turkey	NA
-NA	A/turkey/Jenin/39/2015	avian_flu	EPI_ISL_191528	2015-01-18	Asia	Israel	NA	NA	Turkey	NA
-NA	A/turkey/Israel/274/2015	avian_flu	EPI_ISL_191526	2015-02-10	Asia	Israel	NA	NA	Turkey	NA
-NA	A/turkey/Israel/209/2015	avian_flu	EPI_ISL_191525	2015-02-01	Asia	Israel	NA	NA	Turkey	NA
-NA	A/turkey/Israel/188/2015	avian_flu	EPI_ISL_191524	2015-01-29	Asia	Israel	NA	NA	Turkey	NA
-NA	A/turkey/Israel/174/2015	avian_flu	EPI_ISL_191523	2015-01-29	Asia	Israel	NA	NA	Turkey	NA
 EPI574389|14240FAOs_HA	A/Turkey/Egypt/14240FAOS/2014	avian_flu	EPI_ISL_174924	2014-10-31	Africa	Egypt	NA	NA	Turkey	NA
 EPI574381|14139FAOs_HA	A/Turkey/Egypt/14139FAOS/2014	avian_flu	EPI_ISL_174923	2014-06-18	Africa	Egypt	NA	NA	Turkey	NA
 EPI171604|A/turkey/Poland/R3249/2007	A/turkey/Poland/R3249/2007	avian_flu	EPI_ISL_27763	NA	Europe	Poland	NA	NA	Turkey	NA
@@ -20417,8 +20052,6 @@ EPI965041|A/environment/Bangladesh/23223/2014	A/environment/Bangladesh/23223/201
 EPI270056|A/reassortant/IBCDC-RG7	A/reassortant/IBCDC-RG7 (chicken/India/NIV33487/2006 x Puerto Rico/8/1934)	avian_flu	EPI_ISL_76653	NA	North America	United States	NA	NA	Laboratory derived	NA
 EPI1209765|A/humman/China/MDCK/2017	A/humman/China/MDCK/2017	avian_flu	EPI_ISL_305786	2017-12-07	Asia	China	NA	NA	Unknown	NA
 EPI1209717|A/China/MDCK/2017, EPI1209716|A/China/MDCK/2017	A/China/MDCK/2017	avian_flu	EPI_ISL_305763	2017-12-07	Asia	China	NA	NA	Human	NA
-EPI574132|A/Egypt/MOH-NRC-7305/2014	A/Egypt/MOH-NRC-7305/2014	avian_flu	EPI_ISL_174852	2014-11-28	Africa	Egypt	NA	NA	Human	NA
-EPI574125|A/Egypt/MOH-NRC-7271/2014	A/Egypt/MOH-NRC-7271/2014	avian_flu	EPI_ISL_174851	2014-11-26	Africa	Egypt	NA	NA	Human	NA
 EPI270268|A/Vietnam/HN31432M/2008	A/Vietnam/HN31432M/2008	avian_flu	EPI_ISL_76684	2008-02-21	Asia	Vietnam	NA	NA	Human	NA
 EPI270260|A/Vietnam/UT31413II/2008	A/Vietnam/UT31413II/2008	avian_flu	EPI_ISL_76683	2008-02-13	Asia	Vietnam	NA	NA	Human	NA
 EPI270252|A/Vietnam/UT31412II/2008	A/Vietnam/UT31412II/2008	avian_flu	EPI_ISL_76682	2008-02-09	Asia	Vietnam	NA	NA	Human	NA
@@ -20491,13 +20124,9 @@ EPI770704|MS-a-chkn-ghana-41-2015csh5G	A/chicken/Ghana/41/2015	avian_flu	EPI_ISL
 EPI770696|MS-a-g_fowl-ghana-2-2015E1h5L	A/guinea fowl/Ghana/2/2015	avian_flu	EPI_ISL_223937	2015-07-27	Africa	Ghana	NA	NA	Avian	NA
 EPI770688|MS-a-goose-ghana-17-2015csh5L	A/goose/Ghana/17/2015	avian_flu	EPI_ISL_223936	2015-07-27	Africa	Ghana	NA	NA	Avian	NA
 EPI770680|MS-a-chkn-ghana-46-2015csh5G	A/chicken/Ghana/46/2015	avian_flu	EPI_ISL_223935	2015-08-07	Africa	Ghana	NA	NA	Avian	NA
-EPI770672|MS-a-chkn-ghana-46-2015E1h5G	A/chicken/Ghana/46/2015	avian_flu	EPI_ISL_223934	2015-08-07	Africa	Ghana	NA	NA	Avian	NA
 EPI770664|MS-a-chkn-ghana-29-2015csh5Y	A/chicken/Ghana/29/2015	avian_flu	EPI_ISL_223933	2015-05-22	Africa	Ghana	NA	NA	Avian	NA
-EPI770656|MS-a-chkn-ghana-29-2015E1h5Y	A/chicken/Ghana/29/2015	avian_flu	EPI_ISL_223932	2015-05-22	Africa	Ghana	NA	NA	Avian	NA
 EPI770648|MS-a-chkn-ghana-24-2015csh5L	A/chicken/Ghana/24/2015	avian_flu	EPI_ISL_223931	2015-07-27	Africa	Ghana	NA	NA	Avian	NA
-EPI770640|MS-a-chkn-ghana-24-2015E1h5L	A/chicken/Ghana/24/2015	avian_flu	EPI_ISL_223930	2015-07-27	Africa	Ghana	NA	NA	Avian	NA
 EPI770632|MS-a-chkn-ghana-20-2015csh5L	A/chicken/Ghana/20/2015	avian_flu	EPI_ISL_223929	2015-07-27	Africa	Ghana	NA	NA	Avian	NA
-EPI770624|MS-a-chkn-ghana-20-2015E1h5L	A/chicken/Ghana/20/2015	avian_flu	EPI_ISL_223928	2015-07-27	Africa	Ghana	NA	NA	Avian	NA
 EPI623582|A/crow/India/11TI07/2011	A/crow/India/11TI07/2011	avian_flu	EPI_ISL_191467	NA	Asia	India	NA	NA	Avian	NA
 EPI3089242|A/chicken/Egypt/08102s-NLQP/2009_HA	A/chicken/Egypt/08102s-NLQP/2009	avian_flu	EPI_ISL_18950684	2009-08-25	Africa	Egypt	NA	NA	Chicken	NA
 EPI2009951|A/chicken/Germany-BB/AI06242/2021	A/chicken/Germany-BB/AI06242/2021	avian_flu	EPI_ISL_11725988	2021-11-02	Europe	Germany	Brandenburg	Spree-Neiße	Chicken	Domestic
@@ -20579,19 +20208,13 @@ EPI962549|A/chicken/Cambodia/a0511503/2016	A/chicken/Cambodia/a0511503/2016	avia
 EPI962542|A/chicken/Cambodia/a0511502/2016	A/chicken/Cambodia/a0511502/2016	avian_flu	EPI_ISL_256526	2016-05-10	Asia	Cambodia	Khett Kampot	NA	Chicken	NA
 EPI962535|A/chicken/Cambodia/a0511501/2016	A/chicken/Cambodia/a0511501/2016	avian_flu	EPI_ISL_256525	2016-05-10	Asia	Cambodia	Khett Kampot	NA	Chicken	NA
 NA	A/chicken/Qalqilya/333/2015	avian_flu	EPI_ISL_191527	2015-02-19	Asia	Israel	NA	NA	Chicken	NA
-NA	A/chicken/Israel/156/2015	avian_flu	EPI_ISL_191522	2015-01-28	Asia	Israel	NA	NA	Chicken	NA
-NA	A/chicken/Israel/88/2015	avian_flu	EPI_ISL_191521	2015-01-22	Asia	Israel	NA	NA	Chicken	NA
-NA	A/chicken/Qalqilya/53/2015	avian_flu	EPI_ISL_191520	2015-01-20	Asia	Israel	NA	NA	Chicken	NA
 EPI623578|A/chicken/India/04MO04/2012	A/chicken/India/04MO04/2012	avian_flu	EPI_ISL_191466	NA	Asia	India	NA	NA	Chicken	NA
 EPI623577|A/chicken/India/04MO03/2012	A/chicken/India/04MO03/2012	avian_flu	EPI_ISL_191465	NA	Asia	India	NA	NA	Chicken	NA
 EPI623573|A/chicken/India/03CA02/2013	A/chicken/India/03CA02/2013	avian_flu	EPI_ISL_191463	NA	Asia	India	NA	NA	Chicken	NA
 EPI514996|A/chicken/Malaysia/5744/2004	A/chicken/Malaysia/5744/2004	avian_flu	EPI_ISL_158777	2004-08-17	Asia	Malaysia	NA	NA	Chicken	NA
 EPI453490|A/chicken/Soc Trang/4/2012	A/chicken/Soc Trang/4/2012	avian_flu	EPI_ISL_142232	2012-06-07	Asia	Vietnam	NA	NA	Chicken	Domestic
 EPI323284|A/chicken/Lahore/NARC-3320/2006	A/chicken/Lahore/NARC-3320/2006	avian_flu	EPI_ISL_93031	2006-04-18	Asia	Pakistan	NA	NA	Chicken	NA
-EPI210057|A/chicken/Adygea/203/06	A/chicken/Adygea/203/06	avian_flu	EPI_ISL_60018	NA	Europe	Russian Federation	Krasnodar Krai	NA	Chicken	Domestic
-EPI210043|A/chicken/Krasnodar/199/06	A/chicken/Krasnodar/199/06	avian_flu	EPI_ISL_60013	NA	Europe	Russian Federation	Krasnodar Krai	NA	Chicken	Domestic
 EPI210035|A/chicken/Rostov/864/07	A/chicken/Rostov/864/07	avian_flu	EPI_ISL_60012	NA	Europe	Russian Federation	Rostov Oblast	NA	Chicken	Domestic
-EPI210009|A/chicken/Volgograd/236/06	A/chicken/Volgograd/236/06	avian_flu	EPI_ISL_60002	NA	Europe	Russian Federation	Volgograd Oblast	NA	Chicken	Domestic
 EPI210001|A/chicken/Krasnodar/776/2007	A/chicken/Krasnodar/776/2007	avian_flu	EPI_ISL_60001	NA	Europe	Russian Federation	Krasnodar Krai	NA	Chicken	Domestic
 EPI171660|A/chicken/Germany/R3234/2007	A/chicken/Germany/R3234/2007	avian_flu	EPI_ISL_27773	NA	Europe	Germany	NA	NA	Chicken	NA
 EPI171652|A/chicken/Germany/R3294/2007	A/chicken/Germany/R3294/2007	avian_flu	EPI_ISL_27772	NA	Europe	Germany	NA	NA	Chicken	NA
@@ -20963,7 +20586,6 @@ EPI2161523|A/poultry/Benin/21-A-08-033-O/2021	A/poultry/Benin/21-A-08-033-O/2021
 EPI2161516|A/poultry/Benin/21-A-08-009-O/2021	A/poultry/Benin/21-A-08-009-O/2021	avian_flu	EPI_ISL_14871336	2021-08-01	Africa	Benin	NA	NA	Poultry	NA
 EPI2161509|A/poultry/Benin/21-A-08-035-O/2021	A/poultry/Benin/21-A-08-035-O/2021	avian_flu	EPI_ISL_14871335	2021-09-01	Africa	Benin	NA	NA	Poultry	NA
 EPI1665344|A/chicken/Long An/1427VTC/2019	A/chicken/Long An/1427VTC/2019	avian_flu	EPI_ISL_404210	2019-01-03	Asia	Vietnam	Tinh Long An	NA	Gallus gallus domesticus	Domestic
-EPI1665336|A/chicken/Long An/1427VTC/2019	A/chicken/Long An/1427VTC/2019	avian_flu	EPI_ISL_404209	2019-01-03	Asia	Vietnam	Tinh Long An	NA	Gallus gallus domesticus	Domestic
 EPI455013|A/ruddy turnstone/New Jersey/AI07-699/2007	A/ruddy turnstone/New Jersey/AI07-699/2007	avian_flu	EPI_ISL_142344	2007-08-10	North America	United States	NA	NA	Arenaria interpres	NA
 EPI455006|A/ruddy turnstone/New Jersey/AI07-69/2007	A/ruddy turnstone/New Jersey/AI07-69/2007	avian_flu	EPI_ISL_142343	2007-07-26	North America	United States	NA	NA	Arenaria interpres	NA
 EPI171687|A/Peregrine_falcon/Slovakia/Vh242/2006	A/Peregrine falcon/Slovakia/Vh242/2006	avian_flu	EPI_ISL_27786	NA	Europe	Slovakia	NA	NA	Falco peregrinus	NA
@@ -20986,7 +20608,6 @@ EPI116499|A/goose/Viet_Nam/324/2001, EPI236718|A/goose/Viet Nam/324/2001	A/goose
 EPI116497|A/goose/Viet_Nam/113/2001, EPI236710|A/goose/Viet Nam/113/2001	A/goose/Viet Nam/113/2001	avian_flu	EPI_ISL_11881	NA	Asia	Vietnam	NA	NA	Goose	NA
 EPI116232|A/grey_lag_goose/Denmark/6692/06	A/grey lag goose/Denmark/6692/06	avian_flu	EPI_ISL_11844	NA	Europe	Denmark	NA	NA	Goose	NA
 EPI115454|A/goose/Cambodia/28/2004	A/goose/Cambodia/28/2004	avian_flu	EPI_ISL_11508	2004-01-16	Asia	Cambodia	NA	NA	Goose	NA
-NA	A/goose/Cambodia/022b/2005	avian_flu	EPI_ISL_11505	NA	Asia	Cambodia	NA	NA	Goose	NA
 EPI115436|A/goose/Egypt/13009N3-SM2/2006	A/goose/Egypt/13009N3-SM2/2006	avian_flu	EPI_ISL_11500	NA	Africa	Egypt	NA	NA	Goose	NA
 EPI115111|A/goose/Hungary/3413/2007	A/goose/Hungary/3413/2007	avian_flu	EPI_ISL_11425	NA	Europe	Hungary	NA	NA	Goose	NA
 EPI171737|A/domestic_goose/Germany/R1400/07	A/domestic goose/Germany/R1400/07	avian_flu	EPI_ISL_27795	NA	Europe	Germany	NA	NA	Anser anser	NA
@@ -21000,11 +20621,8 @@ EPI775034|A/pheasant/TienGiang/0024/2013	A/pheasant/TienGiang/0024/2013	avian_fl
 EPI775026|A/pheasant/TienGiang/0022/2013	A/pheasant/TienGiang/0022/2013	avian_flu	EPI_ISL_224900	2013-02-04	Asia	Vietnam	NA	NA	Pheasant	NA
 EPI775018|A/pheasant/TienGiang/0021/2013	A/pheasant/TienGiang/0021/2013	avian_flu	EPI_ISL_224899	2013-02-04	Asia	Vietnam	NA	NA	Pheasant	NA
 EPI775010|A/pheasant/TienGiang/0020/2013	A/pheasant/TienGiang/0020/2013	avian_flu	EPI_ISL_224898	2013-02-04	Asia	Vietnam	NA	NA	Pheasant	NA
-EPI327093|A/Silver Pheasant/Thailand/VSMU-1-CBI/2005	A/Silver Pheasant/Thailand/VSMU-1-CBI/2005	avian_flu	EPI_ISL_94012	NA	Asia	Thailand	NA	NA	Lophura nycthemera	NA
 EPI116234|A/peacock/Denmark/60295/06	A/peacock/Denmark/60295/06	avian_flu	EPI_ISL_11845	NA	Europe	Denmark	NA	NA	Polyplectron bicalcaratum	NA
 EPI2014985|A/swan/Romania/16905_22VIR2749-1/2021_HA	A/swan/Romania/16905_22VIR2749-1/2021	avian_flu	EPI_ISL_11922815	2021-12-08	Europe	Romania	NA	NA	Swan	NA
-EPI2580012|A/whooper swan/Henan/01B/2015	A/whooper swan/Henan/01B/2015	avian_flu	EPI_ISL_209001	2015-01-06	Asia	China	Henan Province	NA	Swan	NA
-EPI2580009|A/whooper swan/Shanxi/17L/2015	A/whooper swan/Shanxi/17L/2015	avian_flu	EPI_ISL_208999	2015-01-06	Asia	China	Shanxi Province	NA	Swan	NA
 EPI115019|A/swan/Austria/216/2006	A/swan/Austria/216/2006	avian_flu	EPI_ISL_11412	NA	Europe	Austria	NA	NA	Swan	NA
 EPI116244|A/whooper_swan/Denmark/7275/06	A/whooper swan/Denmark/7275/06	avian_flu	EPI_ISL_11850	NA	Europe	Denmark	NA	NA	Cygnus cygnus	NA
 EPI116242|A/whooper_swan/Denmark/7224/06	A/whooper swan/Denmark/7224/06	avian_flu	EPI_ISL_11849	NA	Europe	Denmark	NA	NA	Cygnus cygnus	NA
@@ -21018,8 +20636,6 @@ EPI1950487|A/turkey/Lisbon/1/2021	A/turkey/Lisbon/1/2021	avian_flu	EPI_ISL_84168
 EPI1215565|A/turkey/East_Java/Av157/2013	A/turkey/East_Java/Av157/2013	avian_flu	EPI_ISL_307003	2013-09-11	Asia	Indonesia	East Java	Surabaya	Turkey	Domestic
 EPI1215564|A/turkey/East_Java/Av154/2013	A/turkey/East_Java/Av154/2013	avian_flu	EPI_ISL_307002	2013-09-11	Asia	Indonesia	East Java	Surabaya	Turkey	Domestic
 EPI965961|A/turkey/Menia/15248S/2015	A/turkey/Menia/15248S/2015	avian_flu	EPI_ISL_257165	2015-02-26	Africa	Egypt	NA	NA	Turkey	NA
-EPI460139|A/turkey/Turkey/1/2005, EPI460138|A/turkey/Turkey/1/2005	A/turkey/Turkey/1/2005	avian_flu	EPI_ISL_143464	NA	Asia	Turkey	NA	NA	Turkey	NA
-EPI102703|A/turkey/Turkey/1/2005	A/turkey/Turkey/1/2005	avian_flu	EPI_ISL_143438	NA	Asia	Turkey	NA	NA	Turkey	NA
 EPI214938|A/turkey/Egypt/0959-NLQP/2009	A/turkey/Egypt/0959-NLQP/2009	avian_flu	EPI_ISL_61673	NA	Africa	Egypt	NA	NA	Turkey	NA
 EPI214937|A/turkey/Egypt/0935-NLQP/2009	A/turkey/Egypt/0935-NLQP/2009	avian_flu	EPI_ISL_61672	NA	Africa	Egypt	NA	NA	Turkey	NA
 EPI214936|A/turkey/Egypt/091Q-NLQP/2009	A/turkey/Egypt/091Q-NLQP/2009	avian_flu	EPI_ISL_61671	NA	Africa	Egypt	NA	NA	Turkey	NA
@@ -21061,7 +20677,6 @@ EPI174268|A/sparrow/Turkey/Bafra_1096/2006	A/sparrow/Turkey/Bafra 1096/2006	avia
 EPI174255|A/wild_bird/Turkey/Bafra_29/2006	A/wild bird/Turkey/Bafra 29/2006	avian_flu	EPI_ISL_28944	NA	Asia	Turkey	NA	NA	Other avian	NA
 EPI174238|A/sparrow/Turkey/Bafra_1095/2006	A/sparrow/Turkey/Bafra 1095/2006	avian_flu	EPI_ISL_28927	NA	Asia	Turkey	NA	NA	Other avian	NA
 EPI174234|A/pigeon/Turkey/Merkez_1334/2006	A/pigeon/Turkey/Merkez 1334/2006	avian_flu	EPI_ISL_28923	NA	Asia	Turkey	NA	NA	Other avian	NA
-EPI171745|A/great_crested_grebe/Germany/R1406/07	A/great crested grebe/Germany/R1406/07	avian_flu	EPI_ISL_27797	NA	Europe	Germany	NA	NA	Other avian	NA
 EPI171701|A/Ardea_cinerea/Slovenia/185/06	A/Ardea cinerea/Slovenia/185/06	avian_flu	EPI_ISL_27792	NA	Europe	Slovenia	NA	NA	Other avian	NA
 EPI119133|A/heron/Cicurug/IPB25-RS/2006	A/heron/Cicurug/IPB25-RS/2006	avian_flu	EPI_ISL_12649	NA	Asia	Indonesia	West Java	Kelurahan Cicurug	Other avian	NA
 EPI118596|A/wood_duck/MD/04-623/2004	A/wood duck/MD/04-623/2004	avian_flu	EPI_ISL_12516	NA	North America	United States	Maryland	NA	Other avian	NA
@@ -21104,8 +20719,6 @@ EPI1777428|A/environment/Bangladesh/NRL-AI-990/2016	A/environment/Bangladesh/NRL
 EPI1777420|A/environment/Bangladesh/NRL-AI-1610/2016	A/environment/Bangladesh/NRL-AI-1610/2016	avian_flu	EPI_ISL_503327	2016-12-27	Asia	Bangladesh	Dhaka Division	NA	Other environment	NA
 EPI1777412|A/environment/Bangladesh/NRL-AI-1003/2016	A/environment/Bangladesh/NRL-AI-1003/2016	avian_flu	EPI_ISL_503326	2016-07-13	Asia	Bangladesh	Dhaka Division	NA	Other environment	NA
 NA	A/KienGiang/MB1203/2012	avian_flu	EPI_ISL_224909	2012-01-16	Asia	Vietnam	NA	NA	Human	NA
-EPI624930|A/Vietnam/VP13-28H/2013	A/Vietnam/VP13-28H/2013	avian_flu	EPI_ISL_191956	2013-04-04	Asia	Vietnam	Tinh Dong Thap	NA	Human	NA
-EPI624922|A/Vietnam/14012902/2014	A/Vietnam/14012902/2014	avian_flu	EPI_ISL_191955	2014-01-28	Asia	Vietnam	Tinh Dong Thap	NA	Human	NA
 EPI624914|A/Vietnam/14011801/2014	A/Vietnam/14011801/2014	avian_flu	EPI_ISL_191954	2014-01-18	Asia	Vietnam	Tinh Binh Phuoc	NA	Human	NA
 EPI460502|2009711936_155979_v1_4	A/Vietnam/HN31641/2009	avian_flu	EPI_ISL_143548	2009-02-12	Asia	Vietnam	NA	NA	Human	NA
 EPI460494|2008740528_136216_v1_4	A/Vietnam/HN31413/2008	avian_flu	EPI_ISL_143547	2008-01-07	Asia	Vietnam	NA	NA	Human	NA
@@ -21118,11 +20731,9 @@ EPI460365|2012786518_218001_v1_4	A/Egypt/N01400/2012	avian_flu	EPI_ISL_143494	20
 EPI460345|2012705818_206862_v1_4	A/Vietnam/N74/2008	avian_flu	EPI_ISL_143490	2008-04-07	Asia	Vietnam	NA	NA	Human	NA
 EPI460337|2011700097_186961_v1_4	A/Vietnam/HN31673/2009	avian_flu	EPI_ISL_143489	2009-03-12	Asia	Vietnam	NA	NA	Human	NA
 EPI460329|2012705826_209035_v1_4	A/Vietnam/VP12-3/2012	avian_flu	EPI_ISL_143488	2012-01-14	Asia	Vietnam	NA	NA	Human	NA
-EPI361815|A/Thailand/1(KAN-1)/2004	A/Thailand/1(KAN-1)/2004	avian_flu	EPI_ISL_110187	NA	Asia	Thailand	Kanchanaburi	NA	Human	NA
 EPI361794|A/Cambodia/W0112303/2012	A/Cambodia/W0112303/2012	avian_flu	EPI_ISL_110159	2012-01-10	Asia	Cambodia	NA	NA	Human	NA
 EPI361768|A/Cambodia/V0813302/2011	A/Cambodia/V0813302/2011	avian_flu	EPI_ISL_110130	2011-08-18	Asia	Cambodia	NA	NA	Human	NA
 EPI361765|A/Cambodia/V0719348/2011	A/Cambodia/V0719348/2011	avian_flu	EPI_ISL_110129	2011-07-19	Asia	Cambodia	NA	NA	Human	NA
-EPI361524|A/Viet Nam/1203/2004	A/Viet Nam/1203/2004	avian_flu	EPI_ISL_109928	NA	Asia	Vietnam	NA	NA	Human	NA
 EPI275670|A/Thailand/WRAIR1724H/2004	A/Thailand/WRAIR1724H/2004	avian_flu	EPI_ISL_77975	NA	Asia	Thailand	Suphan Buri	NA	Human	NA
 EPI275662|A/Thailand/WRAIR1723H/2004	A/Thailand/WRAIR1723H/2004	avian_flu	EPI_ISL_77974	NA	Asia	Thailand	Suphan Buri	NA	Human	NA
 EPI275654|A/Thailand/WRAIR1722H/2004	A/Thailand/WRAIR1722H/2004	avian_flu	EPI_ISL_77973	NA	Asia	Thailand	Suphan Buri	NA	Human	NA
@@ -21131,13 +20742,9 @@ EPI275638|A/Thailand/WRAIR1720H/2004	A/Thailand/WRAIR1720H/2004	avian_flu	EPI_IS
 EPI173707|A/Egypt/321/2007	A/Egypt/321/2007	avian_flu	EPI_ISL_28832	NA	Africa	Egypt	NA	NA	Human	NA
 EPI118835|A/Turkey/65596/2006	A/Turkey/65596/2006	avian_flu	EPI_ISL_12588	NA	Asia	Turkey	NA	NA	Human	NA
 EPI118816|A/Turkey/651242/2006	A/Turkey/651242/2006	avian_flu	EPI_ISL_12587	NA	Asia	Turkey	NA	NA	Human	NA
-EPI118814|A/Turkey/15/2006	A/Turkey/15/2006	avian_flu	EPI_ISL_12586	NA	Asia	Turkey	NA	NA	Human	NA
-EPI118798|A/Turkey/12/2006	A/Turkey/12/2006	avian_flu	EPI_ISL_12585	NA	Asia	Turkey	NA	NA	Human	NA
 EPI117855|A/Beijing/01/2003	A/Beijing/01/2003	avian_flu	EPI_ISL_12401	NA	Asia	China	NA	NA	Human	NA
 NA	A/Thailand/Prachinburi/6231/2004	avian_flu	EPI_ISL_11915	NA	Asia	Thailand	NA	NA	Human	NA
-NA	A/Thailand/Chaiyaphum/622/2004	avian_flu	EPI_ISL_11894	NA	Asia	Thailand	Chaiyaphum	NA	Human	NA
 EPI116521|A/Thailand/Kan353/2004	A/Thailand/Kan353/2004	avian_flu	EPI_ISL_11889	NA	Asia	Thailand	NA	NA	Human	NA
-NA	A/Hong Kong/213/2003	avian_flu	EPI_ISL_11884	NA	Asia	China	NA	NA	Human	NA
 EPI116470|A/Egypt/2621-NAMRU3/2007	A/Egypt/2621-NAMRU3/2007	avian_flu	EPI_ISL_11875	2007-03-25	Africa	Egypt	Qena	Markaz Qina	Human	NA
 EPI116468|A/Egypt/2620-NAMRU3/2007	A/Egypt/2620-NAMRU3/2007	avian_flu	EPI_ISL_11874	2007-03-25	Africa	Egypt	NA	NA	Human	NA
 EPI116466|A/Egypt/2616-NAMRU3/2007	A/Egypt/2616-NAMRU3/2007	avian_flu	EPI_ISL_11873	2007-03-24	Africa	Egypt	Aswan	Aswan	Human	NA
@@ -21148,16 +20755,12 @@ EPI116458|A/Egypt/1902-NAMRU3/2007	A/Egypt/1902-NAMRU3/2007	avian_flu	EPI_ISL_11
 EPI116456|A/Egypt/1731-NAMRU3/2007	A/Egypt/1731-NAMRU3/2007	avian_flu	EPI_ISL_11868	2007-02-14	Africa	Egypt	NA	NA	Human	NA
 EPI116454|A/Egypt/1604-NAMRU3/2007	A/Egypt/1604-NAMRU3/2007	avian_flu	EPI_ISL_11867	2007-02-12	Africa	Egypt	Faiyum	NA	Human	NA
 EPI116452|A/Egypt/1394-NAMRU3/2007	A/Egypt/1394-NAMRU3/2007	avian_flu	EPI_ISL_11866	2007-02-05	Africa	Egypt	Faiyum	NA	Human	NA
-NA	A/Prachinburi/6231/2004	avian_flu	EPI_ISL_11828	NA	Asia	Thailand	NA	NA	Human	NA
-EPI152380|A/Thailand/16/2004	A/Thailand/16/2004	avian_flu	EPI_ISL_11485	NA	Asia	Thailand	NA	NA	Human	NA
-EPI116507|A/Viet_Nam/1204/2004	A/Viet Nam/1204/2004	avian_flu	EPI_ISL_11484	NA	Asia	Vietnam	NA	NA	Human	NA
 EPI115181|A/Viet_Nam/HN30408/2005	A/Viet Nam/HN30408/2005	avian_flu	EPI_ISL_11449	NA	Asia	Vietnam	NA	NA	Human	NA
 EPI115179|A/Viet_Nam/JPHN30321/2005	A/Viet Nam/JPHN30321/2005	avian_flu	EPI_ISL_11448	NA	Asia	Vietnam	NA	NA	Human	NA
 EPI115173|A/Viet_Nam/JP14/2005	A/Viet Nam/JP14/2005	avian_flu	EPI_ISL_11447	NA	Asia	Vietnam	NA	NA	Human	NA
 EPI115171|A/Viet_Nam/JP4207/2005	A/Viet Nam/JP4207/2005	avian_flu	EPI_ISL_11446	NA	Asia	Vietnam	NA	NA	Human	NA
 EPI115165|A/Viet_Nam/JP178/2004	A/Viet Nam/JP178/2004	avian_flu	EPI_ISL_11444	NA	Asia	Vietnam	NA	NA	Human	NA
 EPI115185|A/Cambodia/JP52a/2005	A/Cambodia/JP52a/2005	avian_flu	EPI_ISL_11443	NA	Asia	Cambodia	NA	NA	Human	NA
-EPI116519|A/Thailand/SP83/2004	A/Thailand/SP83/2004	avian_flu	EPI_ISL_11428	NA	Asia	Thailand	NA	NA	Human	NA
 EPI115007|A/Egypt/0636-NAMRU3/2007	A/Egypt/0636-NAMRU3/2007	avian_flu	EPI_ISL_11410	NA	Africa	Egypt	NA	NA	Human	NA
 EPI1986101|A/duck/Bangladesh/17D1601/2021	A/duck/Bangladesh/17D1601/2021	avian_flu	EPI_ISL_9957422	2021-02-14	Asia	Bangladesh	NA	NA	Avian	NA
 EPI969242|A/wild bird/Shaanxi/Qinling-1/2015	A/wild bird/Shaanxi/Qinling-1/2015	avian_flu	EPI_ISL_257697	NA	Asia	China	NA	NA	Avian	Wild
@@ -21341,15 +20944,7 @@ EPI174345|A/chicken/Turkey/Siirt_Bor399/2006	A/chicken/Turkey/Siirt Bor399/2006	
 EPI174344|A/chicken/Turkey/Hilvan_ist271/2006	A/chicken/Turkey/Hilvan ist271/2006	avian_flu	EPI_ISL_29033	NA	Asia	Turkey	NA	NA	Chicken	NA
 EPI174343|A/chicken/Turkey/GOP_ist56/2006	A/chicken/Turkey/GOP ist56/2006	avian_flu	EPI_ISL_29032	NA	Asia	Turkey	NA	NA	Chicken	NA
 EPI174342|A/chicken/Turkey/K.Cekmece_ist55/2006	A/chicken/Turkey/K.Cekmece ist55/2006	avian_flu	EPI_ISL_29031	NA	Asia	Turkey	NA	NA	Chicken	NA
-EPI174341|A/chicken/Turkey/Misinli_ist582/2006	A/chicken/Turkey/Misinli ist582/2006	avian_flu	EPI_ISL_29030	NA	Asia	Turkey	NA	NA	Chicken	NA
-EPI174340|A/chicken/Turkey/Sirapinar_ist706/2006	A/chicken/Turkey/Sirapinar ist706/2006	avian_flu	EPI_ISL_29029	NA	Asia	Turkey	NA	NA	Chicken	NA
 EPI174339|A/chicken/Turkey/Yalikoy_ist81/2006	A/chicken/Turkey/Yalikoy ist81/2006	avian_flu	EPI_ISL_29028	NA	Asia	Turkey	NA	NA	Chicken	NA
-EPI174338|A/chicken/Turkey/Esetce_ist986/2006	A/chicken/Turkey/Esetce ist986/2006	avian_flu	EPI_ISL_29027	NA	Asia	Turkey	NA	NA	Chicken	NA
-EPI174337|A/chicken/Turkey/Goncaaydin_ist982/2006	A/chicken/Turkey/Goncaaydin ist982/2006	avian_flu	EPI_ISL_29026	2006-03-06	Asia	Turkey	NA	NA	Chicken	NA
-EPI174336|A/chicken/Turkey/B.Cekmece_ist980/2006	A/chicken/Turkey/B.Cekmece ist980/2006	avian_flu	EPI_ISL_29025	NA	Asia	Turkey	NA	NA	Chicken	NA
-EPI174335|A/chicken/Turkey/Silivri_ist962/2006	A/chicken/Turkey/Silivri ist962/2006	avian_flu	EPI_ISL_29024	2006-02-27	Asia	Turkey	NA	NA	Chicken	NA
-EPI174334|A/chicken/Turkey/Baklali_ist955/2006	A/chicken/Turkey/Baklali ist955/2006	avian_flu	EPI_ISL_29023	NA	Asia	Turkey	NA	NA	Chicken	NA
-EPI174333|A/chicken/Turkey/Enez_ist929/2006	A/chicken/Turkey/Enez ist929/2006	avian_flu	EPI_ISL_29022	NA	Asia	Turkey	NA	NA	Chicken	NA
 EPI174332|A/chicken/Turkey/Begendik_ist918/2006	A/chicken/Turkey/Begendik ist918/2006	avian_flu	EPI_ISL_29021	NA	Asia	Turkey	NA	NA	Chicken	NA
 EPI174331|A/chicken/Turkey/Samsun_ist54/2006	A/chicken/Turkey/Samsun ist54/2006	avian_flu	EPI_ISL_29020	NA	Asia	Turkey	NA	NA	Chicken	NA
 EPI174330|A/chicken/Turkey/Belalcin_ist53/2006	A/chicken/Turkey/Belalcin ist53/2006	avian_flu	EPI_ISL_29019	NA	Asia	Turkey	NA	NA	Chicken	NA
@@ -21373,7 +20968,6 @@ EPI174308|A/chicken/Turkey/Ucpinar_ist20/2006	A/chicken/Turkey/Ucpinar ist20/200
 EPI174307|A/chicken/Turkey/Ilica_ist19/2006	A/chicken/Turkey/Ilica ist19/2006	avian_flu	EPI_ISL_28996	NA	Asia	Turkey	NA	NA	Chicken	NA
 EPI174306|A/chicken/Turkey/Sirinkoy_ist18/2006	A/chicken/Turkey/Sirinkoy ist18/2006	avian_flu	EPI_ISL_28995	NA	Asia	Turkey	NA	NA	Chicken	NA
 EPI174305|A/chicken/Turkey/Hurriyet_ist17/2006	A/chicken/Turkey/Hurriyet ist17/2006	avian_flu	EPI_ISL_28994	NA	Asia	Turkey	NA	NA	Chicken	NA
-EPI174303|A/chicken/Turkey/Taflan_ist15/2006	A/chicken/Turkey/Taflan ist15/2006	avian_flu	EPI_ISL_28992	NA	Asia	Turkey	NA	NA	Chicken	NA
 EPI174302|A/chicken/Turkey/Cikrik_ist13/2006	A/chicken/Turkey/Cikrik ist13/2006	avian_flu	EPI_ISL_28991	NA	Asia	Turkey	NA	NA	Chicken	NA
 EPI174301|A/chicken/Turkey/Yaylacati_ist12/2006	A/chicken/Turkey/Yaylacati ist12/2006	avian_flu	EPI_ISL_28990	NA	Asia	Turkey	NA	NA	Chicken	NA
 EPI174300|A/chicken/Turkey/Aydintepe_ist11/2006	A/chicken/Turkey/Aydintepe ist11/2006	avian_flu	EPI_ISL_28989	NA	Asia	Turkey	NA	NA	Chicken	NA
@@ -21482,7 +21076,6 @@ EPI116529|A/chicken/Laos/44/2004	A/chicken/Laos/44/2004	avian_flu	EPI_ISL_11893	
 EPI116527|A/chicken/Laos/7192/2004	A/chicken/Laos/7192/2004	avian_flu	EPI_ISL_11892	NA	Asia	Lao, People's Democratic Republic	NA	NA	Chicken	NA
 EPI116525|A/chicken/Laos/7191/2004	A/chicken/Laos/7191/2004	avian_flu	EPI_ISL_11891	NA	Asia	Lao, People's Democratic Republic	NA	NA	Chicken	NA
 EPI116517|A/chicken/Viet_Nam/1/2004	A/chicken/Viet Nam/1/2004	avian_flu	EPI_ISL_11888	2004-01-24	Asia	Vietnam	NA	NA	Chicken	NA
-EPI116513|A/chicken/Viet_Nam/Ncvd8/2003	A/chicken/Viet Nam/Ncvd8/2003	avian_flu	EPI_ISL_11887	NA	Asia	Vietnam	NA	NA	Chicken	NA
 EPI116511|A/chicken/Viet_Nam/Ncvd31/2004	A/chicken/Viet Nam/Ncvd31/2004	avian_flu	EPI_ISL_11886	2004-01-05	Asia	Vietnam	NA	NA	Chicken	NA
 EPI116422|A/chicken/Israel/625/2006	A/chicken/Israel/625/2006	avian_flu	EPI_ISL_11862	NA	Asia	Israel	NA	NA	Chicken	NA
 EPI116416|A/chicken/Israel/397/2006	A/chicken/Israel/397/2006	avian_flu	EPI_ISL_11860	NA	Asia	Israel	NA	NA	Chicken	NA
@@ -21491,8 +21084,6 @@ EPI116136|A/chicken/Moscow/2/2007	A/chicken/Moscow/2/2007	avian_flu	EPI_ISL_1182
 EPI115478|A/chicken/Indonesia/11/2003, EPI235009|A/chicken/Indonesia/11/2003	A/chicken/Indonesia/11/2003	avian_flu	EPI_ISL_11513	2003-12-20	Asia	Indonesia	NA	NA	Chicken	NA
 EPI115476|A/chicken/Indonesia/7/2003	A/chicken/Indonesia/7/2003	avian_flu	EPI_ISL_11512	2003-12-20	Asia	Indonesia	NA	NA	Chicken	NA
 NA	A/chicken/Cambodia/022LC2b/2005	avian_flu	EPI_ISL_11511	NA	Asia	Cambodia	NA	NA	Chicken	NA
-EPI115463|A/chicken/Cambodia/022LC3b/2005	A/chicken/Cambodia/022LC3b/2005	avian_flu	EPI_ISL_11510	NA	Asia	Cambodia	NA	NA	Chicken	NA
-EPI115461|A/chicken/Cambodia/013LC1b/2005	A/chicken/Cambodia/013LC1b/2005	avian_flu	EPI_ISL_11509	NA	Asia	Cambodia	NA	NA	Chicken	NA
 EPI115452|A/chicken/Cambodia/7/2004	A/chicken/Cambodia/7/2004	avian_flu	EPI_ISL_11507	2004-01-12	Asia	Cambodia	NA	NA	Chicken	NA
 EPI115450|A/chicken/Cambodia/1/2004	A/chicken/Cambodia/1/2004	avian_flu	EPI_ISL_11506	2004-01-12	Asia	Cambodia	NA	NA	Chicken	NA
 EPI115440|A/chicken/Egypt/1892N3-HK49/2007	A/chicken/Egypt/1892N3-HK49/2007	avian_flu	EPI_ISL_11502	NA	Africa	Egypt	NA	NA	Chicken	NA
@@ -21515,7 +21106,6 @@ EPI115053|A/chicken/Nakhonphanom/NIAH113718/2006	A/chicken/Nakhonphanom/NIAH1137
 EPI114987|A/chicken/India/NIV33491/06	A/chicken/India/NIV33491/06	avian_flu	EPI_ISL_11409	NA	Asia	India	NA	NA	Chicken	NA
 EPI114969|A/chicken/India/NIV33487/06	A/chicken/India/NIV33487/06	avian_flu	EPI_ISL_11408	NA	Asia	India	NA	NA	Chicken	NA
 EPI114937|A/chicken/West_Java/Cjr3/2005	A/chicken/West Java/Cjr3/2005	avian_flu	EPI_ISL_11403	NA	Asia	Indonesia	West Java	NA	Chicken	NA
-EPI114936|A/chicken/Jakarta/DKI31/2005	A/chicken/Jakarta/DKI31/2005	avian_flu	EPI_ISL_11402	NA	Asia	Indonesia	Jakarta	Jakarta	Chicken	NA
 EPI114934|A/chicken/West_Java/Smihay1/2005	A/chicken/West Java/Smihay1/2005	avian_flu	EPI_ISL_11400	NA	Asia	Indonesia	West Java	NA	Chicken	NA
 EPI114933|A/chicken/Jakarta/DKI3a/2005	A/chicken/Jakarta/DKI3a/2005	avian_flu	EPI_ISL_11399	NA	Asia	Indonesia	Jakarta	Jakarta	Chicken	NA
 EPI114806|A/chicken/Tula/4/05	A/chicken/Tula/4/05	avian_flu	EPI_ISL_11391	NA	Europe	Russian Federation	NA	NA	Chicken	NA
@@ -21538,7 +21128,6 @@ EPI1780135|A/duck/Ha Tinh/HT5/2014	A/duck/Ha Tinh/HT5/2014	avian_flu	EPI_ISL_504
 EPI1780134|A/duck/Ha Tinh/HT4/2014	A/duck/Ha Tinh/HT4/2014	avian_flu	EPI_ISL_503999	2014-02-14	Asia	Vietnam	NA	NA	Duck	NA
 EPI1780133|A/duck/Ha Tinh/HT2/2014	A/duck/Ha Tinh/HT2/2014	avian_flu	EPI_ISL_503998	2014-02-14	Asia	Vietnam	NA	NA	Duck	NA
 EPI1776443|A/duck/China/0935/2017	A/duck/China/0935/2017	avian_flu	EPI_ISL_503026	2017-09-22	Asia	China	NA	NA	Duck	NA
-EPI2580377|A/duck/China/1033/2017	A/duck/China/1033/2017	avian_flu	EPI_ISL_503025	2017-10-20	Asia	China	NA	NA	Duck	NA
 EPI965964|A/duck/Giza/15292S/2015	A/duck/Giza/15292S/2015	avian_flu	EPI_ISL_257168	2015-03-09	Africa	Egypt	Giza	NA	Duck	NA
 EPI965963|A/duck/Dakahlia/1536CAG/2015	A/duck/Dakahlia/1536CAG/2015	avian_flu	EPI_ISL_257167	2015-02-10	Africa	Egypt	Dakahlia	NA	Duck	NA
 EPI965962|A/duck/Cairo/1578CA/2015	A/duck/Cairo/1578CA/2015	avian_flu	EPI_ISL_257166	2015-03-02	Africa	Egypt	Cairo	NA	Duck	NA
@@ -21554,7 +21143,6 @@ EPI775081|A/duck/CaMau/0237/2015	A/duck/CaMau/0237/2015	avian_flu	EPI_ISL_224907
 EPI775073|A/domestic duck/VinhLong/0184/2013	A/domestic duck/VinhLong/0184/2013	avian_flu	EPI_ISL_224906	2013-11-11	Asia	Vietnam	NA	NA	Duck	Domestic
 EPI775066|A/domestic duck/LongAn/0183/2013	A/domestic duck/LongAn/0183/2013	avian_flu	EPI_ISL_224905	2013-08-13	Asia	Vietnam	NA	NA	Duck	Domestic
 EPI704002|A/common pochard/Shanxi/16L/2015	A/common pochard/Shanxi/16L/2015	avian_flu	EPI_ISL_209002	2015-01-06	Asia	China	NA	NA	Duck	NA
-EPI2580010|A/common pochard/Shanxi/16B/2015	A/common pochard/Shanxi/16B/2015	avian_flu	EPI_ISL_209000	2015-01-06	Asia	China	Shanxi Province	NA	Duck	NA
 EPI703799|A/duck/Egypt/5/2015	A/duck/Egypt/5/2015	avian_flu	EPI_ISL_208929	2015-04-06	Africa	Egypt	NA	NA	Duck	NA
 EPI703798|A/duck/Egypt/4/2015	A/duck/Egypt/4/2015	avian_flu	EPI_ISL_208928	2015-04-06	Africa	Egypt	NA	NA	Duck	NA
 EPI703797|A/duck/Egypt/3/2015	A/duck/Egypt/3/2015	avian_flu	EPI_ISL_208927	2015-04-06	Africa	Egypt	NA	NA	Duck	NA
@@ -21583,7 +21171,6 @@ EPI698747|A/duck/Phnom Penh/OIE16/2015/E1(H5N1)HA	partial/A/duck/Phnom Penh/OIE1
 EPI698739|A/duck/Phnom Penh/OIE15/2015/E1(H5N1)HA	partial/A/duck/Phnom Penh/OIE15/2015	avian_flu	EPI_ISL_208041	2014-12-19	Asia	Cambodia	NA	NA	Duck	NA
 EPI698731|A/duck/Phnom Penh/OIE10/2015/E1(H5N1)HA	partial/A/duck/Phnom Penh/OIE10/2015	avian_flu	EPI_ISL_208040	2014-12-19	Asia	Cambodia	NA	NA	Duck	NA
 EPI698715|A/duck/Kampot/OIE42/2015/E1(H5N1)HA	partial/A/duck/Kampot/OIE42/2015	avian_flu	EPI_ISL_208038	2014-12-18	Asia	Cambodia	NA	NA	Duck	NA
-EPI698707|A/duck/Kampot/OIE41/2015/E2(H5N1)HA	partial/A/duck/Kampot/OIE41/2015	avian_flu	EPI_ISL_208037	2014-12-18	Asia	Cambodia	NA	NA	Duck	NA
 EPI698619|A/duck/Phnom Penh/OIE3624/2015/E1(H5N1)HA	partial/A/duck/Phnom Penh/OIE24/2015	avian_flu	EPI_ISL_208026	2014-12-19	Asia	Cambodia	NA	NA	Duck	NA
 EPI698603|A/duck/Phnom Penh/OIE30/2015/E1(H5N1)HA	partial/A/duck/Phnom Penh/OIE30/2015	avian_flu	EPI_ISL_208024	2014-12-19	Asia	Cambodia	NA	NA	Duck	NA
 EPI698595|A/duck/Kampot/OIE44/2015/E2(H5N1)HA	partial/A/duck/Kampot/OIE44/2015	avian_flu	EPI_ISL_208023	2014-12-18	Asia	Cambodia	NA	NA	Duck	NA
@@ -21627,7 +21214,6 @@ EPI214900|A/duck/Egypt/09339S-NLQP/2009	A/duck/Egypt/09339S-NLQP/2009	avian_flu	
 EPI214899|A/duck/Egypt/093-NLQP/2009	A/duck/Egypt/093-NLQP/2009	avian_flu	EPI_ISL_61648	2009-01-12	Africa	Egypt	NA	NA	Duck	NA
 EPI214898|A/duck/Egypt/0926-NLQP/2009	A/duck/Egypt/0926-NLQP/2009	avian_flu	EPI_ISL_61647	NA	Africa	Egypt	NA	NA	Duck	NA
 EPI214897|A/duck/Egypt/09244F-NLQP/2009	A/duck/Egypt/09244F-NLQP/2009	avian_flu	EPI_ISL_61646	NA	Africa	Egypt	NA	NA	Duck	NA
-EPI214896|A/duck/Egypt/0923-NLQP/2009	A/duck/Egypt/0923-NLQP/2009	avian_flu	EPI_ISL_61645	2009-02-09	Africa	Egypt	NA	NA	Duck	NA
 EPI214895|A/duck/Egypt/0918-NLQP/2009	A/duck/Egypt/0918-NLQP/2009	avian_flu	EPI_ISL_61644	NA	Africa	Egypt	NA	NA	Duck	NA
 EPI174226|A/wild_duck/Turkey/Abana_1703/2006	A/wild duck/Turkey/Abana 1703/2006	avian_flu	EPI_ISL_28915	NA	Asia	Turkey	NA	NA	Duck	NA
 EPI174219|A/wild_duck/Turkey/Beypazari_33/2006	A/wild duck/Turkey/Beypazari 33/2006	avian_flu	EPI_ISL_28908	NA	Asia	Turkey	NA	NA	Duck	NA
@@ -21654,7 +21240,6 @@ EPI117129|A/Muscovy_Duck/Viet_Nam/NCVD02/2005	A/Muscovy Duck/Viet Nam/NCVD02/200
 EPI117127|A/Duck/Viet_Nam/NCVD04/2005	A/Duck/Viet Nam/NCVD04/2005	avian_flu	EPI_ISL_12083	NA	Asia	Vietnam	Vinh Phu Tinh	NA	Duck	NA
 EPI117119|A/Duck/Viet_Nam/NCVD06/2005	A/Duck/Viet Nam/NCVD06/2005	avian_flu	EPI_ISL_12079	NA	Asia	Vietnam	Tinh An Giang	NA	Duck	NA
 EPI117117|A/Duck/Viet_Nam/NCVD07/2005	A/Duck/Viet Nam/NCVD07/2005	avian_flu	EPI_ISL_12078	NA	Asia	Vietnam	NA	NA	Duck	NA
-EPI117115|A/Duck/Viet_Nam/NCVD08/2005	A/Duck/Viet Nam/NCVD08/2005	avian_flu	EPI_ISL_12077	NA	Asia	Vietnam	NA	NA	Duck	NA
 NA	A/duck/Viet Nam/Ncvd1/2002	avian_flu	EPI_ISL_11885	NA	Asia	Vietnam	NA	NA	Duck	NA
 EPI116174|A/duck/Phitsanulok/NIAH6-5-0001/2007	A/duck/Phitsanulok/NIAH6-5-0001/2007	avian_flu	EPI_ISL_11826	NA	Asia	Thailand	Phitsanulok	NA	Duck	NA
 EPI115434|A/duck/Egypt/1888N3-SM25/2007	A/duck/Egypt/1888N3-SM25/2007	avian_flu	EPI_ISL_11499	NA	Africa	Egypt	NA	NA	Duck	NA
@@ -21700,7 +21285,6 @@ NA	A/duck/Bangladesh/40479/2019	avian_flu	EPI_ISL_503492	2019-07-11	Asia	Banglad
 EPI1777925|A/duck/Bangladesh/40641/2019	A/duck/Bangladesh/40641/2019	avian_flu	EPI_ISL_503491	2019-08-19	Asia	Bangladesh	NA	NA	Anas sp.	NA
 NA	A/duck/Bangladesh/41054/2019	avian_flu	EPI_ISL_503487	2019-10-16	Asia	Bangladesh	NA	NA	Anas sp.	NA
 EPI1777837|A/duck/Bangladesh/38175/2019	A/duck/Bangladesh/38175/2019	avian_flu	EPI_ISL_503479	2019-02-19	Asia	Bangladesh	NA	NA	Anas sp.	NA
-EPI1215588|A/duck/East_Java/Av259/2014	A/duck/East_Java/Av259/2014	avian_flu	EPI_ISL_307023	2014-02-09	Asia	Indonesia	East Java	Sidoarjo	Anas sp.	Domestic
 EPI1213876|A/duck/Bangladesh/31992/2017	A/duck/Bangladesh/31992/2017	avian_flu	EPI_ISL_306666	2017-02-15	Asia	Bangladesh	NA	NA	Anas sp.	NA
 EPI1213883|A/duck/Bangladesh/32003/2017	A/duck/Bangladesh/32003/2017	avian_flu	EPI_ISL_306662	2017-02-15	Asia	Bangladesh	NA	NA	Anas sp.	NA
 EPI1213809|A/duck/Bangladesh/31993/2017	A/duck/Bangladesh/31993/2017	avian_flu	EPI_ISL_306657	2017-02-15	Asia	Bangladesh	NA	NA	Anas sp.	NA
@@ -21735,7 +21319,6 @@ EPI1850253|A/barnacle goose/Netherlands/21022611-001/2021	A/barnacle goose/Nethe
 EPI2219583|A/chicken/South Africa/236744/2021	A/chicken/South Africa/236744/2021	avian_flu	EPI_ISL_15838771	2021-10-19	Africa	South Africa	Province of the Western Cape	Durbanville	Gallus gallus domesticus	Domestic
 EPI1951309|23404-21 H5	A/chicken/Czech_Republic/23404/2021	avian_flu	EPI_ISL_8515480	2021-11-25	Europe	Czech Republic	South Moravian Region	Okres Breclav	Gallus gallus domesticus	Domestic
 EPI1665368|A/chicken/Long An/1428VTC/2019	A/chicken/Long An/1428VTC/2019	avian_flu	EPI_ISL_404985	2019-01-03	Asia	Vietnam	Tinh Long An	NA	Gallus gallus domesticus	Domestic
-EPI1665360|A/chicken/Long An/1428VTC/2019	A/chicken/Long An/1428VTC/2019	avian_flu	EPI_ISL_404984	2019-01-03	Asia	Vietnam	Tinh Long An	NA	Gallus gallus domesticus	Domestic
 EPI1583636|20h(20VN)	A/chicken/Ha Tinh/20VTC/2015	avian_flu	EPI_ISL_389117	2015-09-09	Asia	Vietnam	Tinh Ha Tinh	NA	Gallus gallus domesticus	NA
 EPI1583628|19h(19VN)	A/chicken/Ha Tinh/19VTC/2015	avian_flu	EPI_ISL_389116	2015-09-27	Asia	Vietnam	Tinh Ha Tinh	NA	Gallus gallus domesticus	NA
 EPI1583614|18h(18VN)	A/chicken/Ha Tinh/18VTC/2015	avian_flu	EPI_ISL_389112	2015-09-01	Asia	Vietnam	Tinh Ha Tinh	NA	Gallus gallus domesticus	NA
@@ -21749,9 +21332,7 @@ EPI1583475|6h(6VN)	A/chicken/Nghe An/06VTC/2017	avian_flu	EPI_ISL_389074	2017-02
 EPI1583444|5h(5VN)	A/chicken/Nghe An/05VTC/2017	avian_flu	EPI_ISL_389065	2017-01-23	Asia	Vietnam	Tinh Nghe An	NA	Gallus gallus domesticus	NA
 EPI1215584|A/chicken/East_Java/Av240/2014	A/chicken/East_Java/Av240/2014	avian_flu	EPI_ISL_307019	2014-02-01	Asia	Indonesia	East Java	Sidoarjo	Gallus gallus domesticus	Domestic
 EPI1215583|A/chicken/East_Java/Av235/2014	A/chicken/East_Java/Av235/2014	avian_flu	EPI_ISL_307018	2014-02-01	Asia	Indonesia	East Java	Sidoarjo	Gallus gallus domesticus	Domestic
-EPI1215582|A/chicken/East_Java/Av225/2014	A/chicken/East_Java/Av225/2014	avian_flu	EPI_ISL_307017	2014-01-26	Asia	Indonesia	East Java	NA	Gallus gallus domesticus	Domestic
 EPI1215580|A/chicken/East_Java/Av194/2014	A/chicken/East_Java/Av194/2014	avian_flu	EPI_ISL_307015	2014-01-25	Asia	Indonesia	East Java	Sidoarjo	Gallus gallus domesticus	Domestic
-EPI1215579|A/chicken/East_Java/Av193/2014	A/chicken/East_Java/Av193/2014	avian_flu	EPI_ISL_307014	2014-01-25	Asia	Indonesia	East Java	Sidoarjo	Gallus gallus domesticus	Domestic
 EPI1215571|A/chicken/East_Java/Av171/2014	A/chicken/East_Java/Av171/2014	avian_flu	EPI_ISL_307008	2014-01-19	Asia	Indonesia	East Java	Sidoarjo	Gallus gallus domesticus	Domestic
 EPI1215567|A/chicken/East_Java/Av166/2014	A/chicken/East_Java/Av166/2014	avian_flu	EPI_ISL_307005	2014-01-19	Asia	Indonesia	East Java	Sidoarjo	Gallus gallus domesticus	Domestic
 EPI1215566|A/chicken/East_Java/Av165/2014	A/chicken/East_Java/Av165/2014	avian_flu	EPI_ISL_307004	2014-01-19	Asia	Indonesia	East Java	Sidoarjo	Gallus gallus domesticus	Domestic
@@ -21780,7 +21361,6 @@ EPI164646|A/Canada_goose/Sweden/V978/06	A/Canada goose/Sweden/V978/06	avian_flu	
 NA	A/Canada goose/Sweden/V828/06	avian_flu	EPI_ISL_13242	NA	Europe	Sweden	NA	NA	Goose	NA
 EPI122771|A/Canada_goose/AK/44075-058/2006	A/Canada goose/AK/44075-058/2006	avian_flu	EPI_ISL_13037	NA	North America	United States	Alaska	NA	Goose	NA
 EPI174763|A/domestic_goose/Constanta/RO-AI-008/2005	A/domestic goose/Constanta/RO-AI-008/2005	avian_flu	EPI_ISL_29216	NA	Europe	Romania	Judetul Constanta	Constanta	Anser anser	NA
-EPI300761|A/bar-headed goose/Mongolia/X53/2009, EPI219308|A/bar-headed goose/Mongolia/X53/2009	A/bar-headed goose/Mongolia/X53/2009	avian_flu	EPI_ISL_62719	NA	Asia	Mongolia	NA	NA	Anser indicus	NA
 EPI174742|A/Guinea_fowl/Constanta/RO-AI-159/2006	A/Guinea fowl/Constanta/RO-AI-159/2006	avian_flu	EPI_ISL_29195	NA	Europe	Romania	Judetul Constanta	Constanta	Guineafowl	NA
 EPI126786|A/guinea_fowl/Burkina_Faso/1347-20/2006	A/guinea fowl/Burkina Faso/1347-20/2006	avian_flu	EPI_ISL_13904	NA	Africa	Burkina Faso	NA	NA	Guineafowl	NA
 EPI221244|A/brown-head gull/Thailand/vsmu-4/2008	A/brown-head gull/Thailand/vsmu-4/2008	avian_flu	EPI_ISL_62986	NA	Asia	Thailand	NA	NA	Gull	NA
@@ -21905,7 +21485,6 @@ EPI331866|A/environment/Maryland/1165/2006	A/environment/Maryland/1165/2006	avia
 EPI331865|A/environment/Maryland/1170/2006	A/environment/Maryland/1170/2006	avian_flu	EPI_ISL_94936	2006-08-02	North America	United States	NA	NA	Environment	NA
 EPI331864|A/environment/Maryland/1171/2006	A/environment/Maryland/1171/2006	avian_flu	EPI_ISL_94935	2006-08-02	North America	United States	NA	NA	Environment	NA
 EPI331863|A/environment/Maryland/1172/2006	A/environment/Maryland/1172/2006	avian_flu	EPI_ISL_94934	2006-08-02	North America	United States	NA	NA	Environment	NA
-EPI331862|A/environment/Maryland/1192/2006	A/environment/Maryland/1192/2006	avian_flu	EPI_ISL_94933	2006-08-02	North America	United States	NA	NA	Environment	NA
 EPI220538|A/environment/Hunan/7-73/2008	A/environment/Hunan/7-73/2008	avian_flu	EPI_ISL_63045	NA	Asia	China	NA	NA	Environment	NA
 EPI220530|A/environment/Hunan/6-69/2008	A/environment/Hunan/6-69/2008	avian_flu	EPI_ISL_63044	NA	Asia	China	NA	NA	Environment	NA
 EPI220522|A/environment/Hunan/6-45/2008	A/environment/Hunan/6-45/2008	avian_flu	EPI_ISL_63043	NA	Asia	China	NA	NA	Environment	NA
@@ -21918,16 +21497,10 @@ EPI174803|A/chicken/Vietnam/NCVD-016/2008(H5N1)-PR8-IDCDC-RG12	A/chicken/Vietnam
 EPI127340|A/India/m777/2007	A/India/m777/2007	avian_flu	EPI_ISL_13969	NA	Asia	India	NA	NA	Laboratory derived	NA
 EPI123519|A/Viet_Nam/1203/2004(H5N1))_isolate_escape_mutant_m777/1, EPI123517|A/Viet_Nam/1203/2004(H5N1))_isolate_escape_mutant_m777/1	A/Viet Nam/1203/2004(H5N1)) isolate escape mutant m777/1	avian_flu	EPI_ISL_13252	NA	Asia	Vietnam	NA	NA	Laboratory derived	NA
 EPI2147693|A/Ciconia ciconia/Spain/4087-5/2021	A/Ciconia ciconia/Spain/4087-5/2021	avian_flu	EPI_ISL_14776054	2021-12-22	Europe	Spain	NA	NA	Host	NA
-EPI1449522|A/Nepal/19FL1997/2019	A/Nepal/19FL1997/2019	avian_flu	EPI_ISL_358020	2019-03-25	Asia	Nepal	NA	NA	Human	NA
-EPI584783|A/Egypt/MOH-NRC-8434/2014	A/Egypt/MOH-NRC-8434/2014	avian_flu	EPI_ISL_177571	2014-12-27	Africa	Egypt	NA	NA	Human	NA
 EPI463648|A/Indonesia/NIHRD13157/2013	A/Indonesia/NIHRD13157/2013	avian_flu	EPI_ISL_144507	2013-06-18	Asia	Indonesia	West Java	NA	Human	NA
 EPI393786|A/Egypt/N02137/2012	A/Egypt/N02137/2012	avian_flu	EPI_ISL_128407	2012-03-29	Africa	Egypt	Giza	NA	Human	NA
 EPI393783|A/Egypt/N00951/2012	A/Egypt/N00951/2012	avian_flu	EPI_ISL_128406	2012-02-21	Africa	Egypt	Beheira	NA	Human	NA
-EPI280112|A/Shanghai/1/2006.4	A/Shanghai/1/2006	avian_flu	EPI_ISL_79679	2006-03-13	Asia	China	Shanghai	NA	Human	NA
-EPI280104|A/Guangdong/1/2006.4	A/Guangdong/1/2006	avian_flu	EPI_ISL_79678	2006-02-22	Asia	China	Guangdong	NA	Human	NA
-EPI280096|A/Hunan/1/2006.4	A/Hunan/1/2006	avian_flu	EPI_ISL_79677	2006-01-27	Asia	China	Hunan	NA	Human	NA
 EPI219470|A/Bangladesh/207095/2008	A/Bangladesh/207095/2008	avian_flu	EPI_ISL_62768	NA	Asia	Bangladesh	NA	NA	Human	NA
-EPI176348|#176348	A/Guangxi/1/2009	avian_flu	EPI_ISL_29508	2009-01-24	Asia	China	Guangxi Zhuang Autonomous Region	NA	Human	NA
 NA	A/Guangdong/01/2006	avian_flu	EPI_ISL_29507	NA	Asia	China	Guangdong Province	NA	Human	NA
 NA	A/Azerbaijan/902838/2006	avian_flu	EPI_ISL_29436	NA	Asia	Azerbaijan	NA	NA	Human	NA
 EPI126828|A/Viet_Nam/HN31242/2007, EPI126826|A/Viet_Nam/HN31242/2007, EPI126824|A/Viet_Nam/HN31242/2007	A/Viet Nam/HN31242/2007	avian_flu	EPI_ISL_13914	NA	Asia	Vietnam	NA	NA	Human	NA
@@ -21971,9 +21544,6 @@ EPI124105|A/Indonesia/175H/2005	A/Indonesia/175H/2005	avian_flu	EPI_ISL_13475	20
 EPI124089|A/Indonesia/7/2005	A/Indonesia/7/2005	avian_flu	EPI_ISL_13474	NA	Asia	Indonesia	NA	NA	Human	NA
 EPI124201|A/Indonesia/283H/2006	A/Indonesia/283H/2006	avian_flu	EPI_ISL_13473	NA	Asia	Indonesia	NA	NA	Human	NA
 EPI124071|A/Indonesia/6/2005	A/Indonesia/6/2005	avian_flu	EPI_ISL_13472	NA	Asia	Indonesia	Jakarta	Jakarta	Human	NA
-EPI122769|A/Egypt/6251-NAMRU3/2007	A/Egypt/6251-NAMRU3/2007	avian_flu	EPI_ISL_13036	2007-07-21	Africa	Egypt	Damietta	NA	Human	NA
-EPI122767|A/Egypt/4226-NAMRU3/2007	A/Egypt/4226-NAMRU3/2007	avian_flu	EPI_ISL_13035	2007-06-21	Africa	Egypt	Qena	Markaz Qina	Human	NA
-EPI122765|A/Egypt/4082-NAMRU3/2007	A/Egypt/4082-NAMRU3/2007	avian_flu	EPI_ISL_13034	2007-06-10	Africa	Egypt	Qena	Markaz Qina	Human	NA
 EPI122763|A/Egypt/4081-NAMRU3/2007	A/Egypt/4081-NAMRU3/2007	avian_flu	EPI_ISL_13033	2007-06-07	Africa	Egypt	Qena	Markaz Qina	Human	NA
 EPI122761|A/Egypt/2751-NAMRU3/2007	A/Egypt/2751-NAMRU3/2007	avian_flu	EPI_ISL_13032	2007-04-06	Africa	Egypt	Cairo	Cairo	Human	NA
 EPI122759|A/Egypt/2750-NAMRU3/2007	A/Egypt/2750-NAMRU3/2007	avian_flu	EPI_ISL_13031	2007-04-04	Africa	Egypt	NA	NA	Human	NA
@@ -22043,7 +21613,6 @@ EPI330996|2011703508_189125_v1_4	A/duck/Vietnam/NCVD-431/2010	avian_flu	EPI_ISL_
 EPI2573875|A/chicken/Banten/Serang/1383/2020	A/chicken/Banten/Serang/1383/2020	avian_flu	EPI_ISL_17708278	2020-02-17	Asia	Indonesia	Banten	Serang	Chicken	Domestic
 EPI2573874|A/chicken/Lampung/1366/2020	A/chicken/Lampung/1366/2020	avian_flu	EPI_ISL_17708277	2020-01-21	Asia	Indonesia	Lampung	NA	Chicken	Domestic
 EPI2573873|A/chicken/WestJava/Cianjur/1380/2020	A/chicken/WestJava/Cianjur/1380/2020	avian_flu	EPI_ISL_17708276	2020-02-13	Asia	Indonesia	West Java	Cianjur	Chicken	Domestic
-EPI1933663|A/chicken/Kagoshima/21A6T/2021(ha)	A/chicken/Kagoshima/21A6T/2021	avian_flu	EPI_ISL_6829533	2021-11-12	Asia	Japan	Kagoshima	NA	Chicken	NA
 EPI1785452|A/chicken/Viet Nam/HU12-661/2019	A/chicken/Viet Nam/HU12-661/2019	avian_flu	EPI_ISL_504983	2019-08-30	Asia	Vietnam	NA	NA	Chicken	NA
 EPI1785444|A/chicken/Viet Nam/HU12-657/2019	A/chicken/Viet Nam/HU12-657/2019	avian_flu	EPI_ISL_504982	2019-08-30	Asia	Vietnam	NA	NA	Chicken	NA
 EPI1785201|A/chicken/Thateng District/NL-1942889/2018	A/chicken/Thateng District/NL-1942889/2018	avian_flu	EPI_ISL_504926	2018-10-10	Asia	Lao, People's Democratic Republic	NA	NA	Chicken	NA
@@ -22186,7 +21755,6 @@ NA	A/chicken/Thailand/CU-355/2008	avian_flu	EPI_ISL_63016	2008-11-14	Asia	Thaila
 EPI220360|A/chicken/Thailand/CU-354/2008	A/chicken/Thailand/CU-354/2008	avian_flu	EPI_ISL_63014	2008-11-14	Asia	Thailand	NA	NA	Chicken	NA
 NA	A/chicken/Thailand/CU-353/2008	avian_flu	EPI_ISL_63013	2008-11-14	Asia	Thailand	NA	NA	Chicken	NA
 NA	A/chicken/Thailand/CU-352/2008	avian_flu	EPI_ISL_63012	2008-11-14	Asia	Thailand	NA	NA	Chicken	NA
-EPI220349|A/chicken/Sukhothai/NIAH114843/2008	A/chicken/Sukhothai/NIAH114843/2008	avian_flu	EPI_ISL_63011	NA	Asia	Thailand	NA	NA	Chicken	NA
 EPI220345|A/chicken/Primorje/1/2008	A/chicken/Primorje/1/2008	avian_flu	EPI_ISL_63010	2008-04-10	Europe	Russian Federation	NA	NA	Chicken	NA
 EPI220311|A/chicken/India/WB-NIV16915/2008	A/chicken/India/WB-NIV16915/2008	avian_flu	EPI_ISL_63002	2008-12-16	Asia	India	NA	NA	Chicken	NA
 EPI220309|A/chicken/India/AS-NIV15983/2008	A/chicken/India/AS-NIV15983/2008	avian_flu	EPI_ISL_63001	2008-11-27	Asia	India	NA	NA	Chicken	NA
@@ -22206,11 +21774,9 @@ EPI180248|A/chicken/Vietnam/NCVD-04/2008	A/chicken/Vietnam/NCVD-04/2008	avian_fl
 EPI180246|A/chicken/Vietnam/NCVD-swab18/2008	A/chicken/Vietnam/NCVD-swab18/2008	avian_flu	EPI_ISL_30423	NA	Asia	Vietnam	NA	NA	Chicken	NA
 EPI180245|A/chicken/Vietnam/NCVD-swab17/2008	A/chicken/Vietnam/NCVD-swab17/2008	avian_flu	EPI_ISL_30422	NA	Asia	Vietnam	NA	NA	Chicken	NA
 EPI180244|A/chicken/Vietnam/NCVD-swab15/2008	A/chicken/Vietnam/NCVD-swab15/2008	avian_flu	EPI_ISL_30421	NA	Asia	Vietnam	NA	NA	Chicken	NA
-EPI180243|A/chicken/Vietnam/NCVD-016/2008	A/chicken/Vietnam/NCVD-016/2008	avian_flu	EPI_ISL_30420	NA	Asia	Vietnam	NA	NA	Chicken	NA
 EPI180247|A/chicken/Vietnam/NCVD-093/2008	A/chicken/Vietnam/NCVD-093/2008	avian_flu	EPI_ISL_29504	NA	Asia	Vietnam	NA	NA	Chicken	NA
 EPI176007|A/chicken/Afghanistan/902764/2006	A/chicken/Afghanistan/902764/2006	avian_flu	EPI_ISL_29435	NA	Asia	Afghanistan	NA	NA	Chicken	NA
 NA	A/chicken/Iraq/900845/2006	avian_flu	EPI_ISL_29434	NA	Asia	Iraq	NA	NA	Chicken	NA
-EPI175819|A/chicken/Vietnam/NCVD-03/2008	A/chicken/Vietnam/NCVD-03/2008	avian_flu	EPI_ISL_29406	NA	Asia	Vietnam	NA	NA	Chicken	NA
 EPI175658|A/chicken/Assam/140203/2008	A/chicken/Assam/140203/2008	avian_flu	EPI_ISL_29375	2008-11-20	Asia	India	Assam	NA	Chicken	NA
 EPI175656|A/chicken/Assam/140187/2008	A/chicken/Assam/140187/2008	avian_flu	EPI_ISL_29374	2008-11-20	Asia	India	Assam	NA	Chicken	NA
 EPI174900|A/chicken/Manipur/NIV9743/2007	A/chicken/Manipur/NIV9743/2007	avian_flu	EPI_ISL_29263	2007-07-19	Asia	India	Manipur	NA	Chicken	NA
@@ -22238,14 +21804,10 @@ EPI174651|A/chicken/Hubei/2856/2007	A/chicken/Hubei/2856/2007	avian_flu	EPI_ISL_
 EPI174647|A/chicken/Hunan/1793/2007	A/chicken/Hunan/1793/2007	avian_flu	EPI_ISL_29180	2007-01-23	Asia	China	Hunan Province	NA	Chicken	NA
 EPI174643|A/chicken/Henan/1362/2006	A/chicken/Henan/1362/2006	avian_flu	EPI_ISL_29176	2006-12-30	Asia	China	Henan Province	NA	Chicken	NA
 EPI174642|A/chicken/Anhui/1089/2007	A/chicken/Anhui/1089/2007	avian_flu	EPI_ISL_29175	2007-01-28	Asia	China	Anhui Province	NA	Chicken	NA
-EPI174583|A/chicken/Uthaithani/NIAH115067/2008	A/chicken/Uthaithani/NIAH115067/2008	avian_flu	EPI_ISL_29171	NA	Asia	Thailand	Uthai Thani	NA	Chicken	NA
 EPI175684|A/chicken/Sihala/NARC3303.4/2006	A/chicken/Sihala/NARC3303.4/2006	avian_flu	EPI_ISL_29083	NA	Asia	Pakistan	NA	NA	Chicken	NA
 EPI175676|A/chicken/Rawalakot/NARC2441A/2006	A/chicken/Rawalakot/NARC2441A/2006	avian_flu	EPI_ISL_29082	NA	Asia	Pakistan	NA	NA	Chicken	NA
 EPI174391|A/chicken/Turkey/Samsun_1751/2008	A/chicken/Turkey/Samsun 1751/2008	avian_flu	EPI_ISL_29080	NA	Asia	Turkey	NA	NA	Chicken	NA
-EPI127778|A/chicken/Togo/4106-1/2007	A/chicken/Togo/4106-1/2007	avian_flu	EPI_ISL_14135	NA	Africa	Togo	NA	NA	Chicken	NA
 EPI127774|A/chicken/Egypt/2628-1/2007	A/chicken/Egypt/2628-1/2007	avian_flu	EPI_ISL_14133	NA	Africa	Egypt	NA	NA	Chicken	NA
-EPI127772|A/chicken/Egypt/452-2/2007	A/chicken/Egypt/452-2/2007	avian_flu	EPI_ISL_14132	NA	Africa	Egypt	NA	NA	Chicken	NA
-EPI127770|A/chicken/Ghana/2534/2007	A/chicken/Ghana/2534/2007	avian_flu	EPI_ISL_14131	2007-04-24	Africa	Ghana	NA	NA	Chicken	NA
 EPI127768|A/chicken/Egypt/06959-NLQP/2006	A/chicken/Egypt/06959-NLQP/2006	avian_flu	EPI_ISL_14130	2006-11-27	Africa	Egypt	Gharbia	NA	Chicken	NA
 EPI127766|A/chicken/Egypt/06541-NLQP/2006	A/chicken/Egypt/06541-NLQP/2006	avian_flu	EPI_ISL_14129	2006-03-20	Africa	Egypt	Cairo	Cairo	Chicken	NA
 EPI127764|A/chicken/Egypt/06495-NLQP/2006	A/chicken/Egypt/06495-NLQP/2006	avian_flu	EPI_ISL_14128	2006-03-17	Africa	Egypt	Sharqia	NA	Chicken	NA
@@ -22331,7 +21893,6 @@ EPI123827|A/Chicken/Indonesia/Pekenbaru1631-11/2006	A/Chicken/Indonesia/Pekenbar
 EPI123825|A/Chicken/Indonesia/Agam1631-3/2006	A/Chicken/Indonesia/Agam1631-3/2006	avian_flu	EPI_ISL_13374	2006-06-01	Asia	Indonesia	NA	NA	Chicken	NA
 EPI123823|A/Chicken/Indonesia/Siak1631-2/2006	A/Chicken/Indonesia/Siak1631-2/2006	avian_flu	EPI_ISL_13373	NA	Asia	Indonesia	NA	NA	Chicken	NA
 EPI123822|A/Chicken/Indonesia/Padang1631-1/2006	A/Chicken/Indonesia/Padang1631-1/2006	avian_flu	EPI_ISL_13372	NA	Asia	Indonesia	NA	NA	Chicken	NA
-NA	A/Chicken/Laos/Xaythiani 26/2006	avian_flu	EPI_ISL_13371	NA	Asia	Lao, People's Democratic Republic	NA	NA	Chicken	NA
 EPI123800|A/Chicken/Laos/Xaythiani_37/2006	A/Chicken/Laos/Xaythiani 37/2006	avian_flu	EPI_ISL_13370	NA	Asia	Lao, People's Democratic Republic	NA	NA	Chicken	NA
 EPI123798|A/Chicken/Laos/Xaythiani_36/2006	A/Chicken/Laos/Xaythiani 36/2006	avian_flu	EPI_ISL_13369	NA	Asia	Lao, People's Democratic Republic	NA	NA	Chicken	NA
 EPI123796|A/Chicken/Laos/Xaythiani_32/2006	A/Chicken/Laos/Xaythiani 32/2006	avian_flu	EPI_ISL_13368	NA	Asia	Lao, People's Democratic Republic	NA	NA	Chicken	NA
@@ -22339,13 +21900,6 @@ EPI123794|A/Chicken/Laos/Xaythiani-26/2006	A/Chicken/Laos/Xaythiani-26/2006	avia
 EPI123843|A/Chicken/Indonesia/Soppeng1631-71/2007	A/Chicken/Indonesia/Soppeng1631-71/2007	avian_flu	EPI_ISL_13366	2007-02-01	Asia	Indonesia	NA	NA	Chicken	NA
 EPI123762|A/Chicken/Vietnam/Binh_Duong477/2005	A/Chicken/Vietnam/Binh Duong477/2005	avian_flu	EPI_ISL_13356	2005-08-10	Asia	Vietnam	NA	NA	Chicken	NA
 EPI123760|A/Chicken/Vietnam/Long_An_636/2005	A/Chicken/Vietnam/Long An 636/2005	avian_flu	EPI_ISL_13355	2005-11-21	Asia	Vietnam	NA	NA	Chicken	NA
-EPI123748|A/Chicken/West_Java/SMI-ENDRI1/2006	A/Chicken/West Java/SMI-ENDRI1/2006	avian_flu	EPI_ISL_13349	2006-05-01	Asia	Indonesia	West Java	NA	Chicken	NA
-EPI123746|A/Chicken/West_Java/SMI-ENDRI2/2006	A/Chicken/West Java/SMI-ENDRI2/2006	avian_flu	EPI_ISL_13348	2006-05-01	Asia	Indonesia	West Java	NA	Chicken	NA
-EPI123740|A/Chicken/Papua/TA5/2006	A/Chicken/Papua/TA5/2006	avian_flu	EPI_ISL_13345	2006-07-01	Asia	Indonesia	Papua	NA	Chicken	NA
-EPI123738|A/Chicken/Papua/TB1/2006	A/Chicken/Papua/TB1/2006	avian_flu	EPI_ISL_13344	2006-07-01	Asia	Indonesia	Papua	NA	Chicken	NA
-EPI123736|A/Chicken/Papua/TB15/2006	A/Chicken/Papua/TB15/2006	avian_flu	EPI_ISL_13343	2006-07-01	Asia	Indonesia	Papua	NA	Chicken	NA
-EPI123734|A/Chicken/West_Java/TASIK1/2006	A/Chicken/West Java/TASIK1/2006	avian_flu	EPI_ISL_13342	2006-07-01	Asia	Indonesia	West Java	NA	Chicken	NA
-EPI123732|A/Chicken/West_Java/TASIK2/2006	A/Chicken/West Java/TASIK2/2006	avian_flu	EPI_ISL_13341	2006-07-01	Asia	Indonesia	West Java	NA	Chicken	NA
 EPI123718|A/Chicken/Madiun/BBVW1420/2005	A/Chicken/Madiun/BBVW1420/2005	avian_flu	EPI_ISL_13334	NA	Asia	Indonesia	East Java	Madiun	Chicken	NA
 NA	A/Chicken/Bandar Lampung/BPPV111/2006	avian_flu	EPI_ISL_13320	NA	Asia	Indonesia	Lampung	Tanjungkarang-Telukbetung	Chicken	NA
 NA	A/Chicken/Way Kanan/BPPV111/2006	avian_flu	EPI_ISL_13319	NA	Asia	Indonesia	NA	NA	Chicken	NA
@@ -22360,17 +21914,11 @@ NA	A/Chicken/Medan/BBPV1-534/2005	avian_flu	EPI_ISL_13311	2005-09-22	Asia	Indone
 NA	A/Chicken/Deli Derdang/BBPV1/2005	avian_flu	EPI_ISL_13310	2005-09-23	Asia	Indonesia	Kabupaten Deli Serdang	NA	Chicken	NA
 NA	A/Chicken/Taput/BBPV1/2005	avian_flu	EPI_ISL_13308	NA	Asia	Indonesia	NA	NA	Chicken	NA
 NA	A/Chicken/Karo/BBPV1/2006	avian_flu	EPI_ISL_13307	2006-01-02	Asia	Indonesia	NA	NA	Chicken	NA
-EPI123614|A/Chicken/Medan/BPPV1-498/2005	A/Chicken/Medan/BPPV1-498/2005	avian_flu	EPI_ISL_13294	2005-09-15	Asia	Indonesia	North Sumatra	Medan	Chicken	NA
-EPI123640|A/Chicken/Pidie/BPPV1/2005, EPI123612|A/Chicken/Pidie/BPPV1/2005	A/Chicken/Pidie/BPPV1/2005	avian_flu	EPI_ISL_13293	NA	Asia	Indonesia	NA	NA	Chicken	NA
 EPI123610|A/chicken/Medan/BPPV1-534/2005	A/chicken/Medan/BPPV1-534/2005	avian_flu	EPI_ISL_13292	2005-09-22	Asia	Indonesia	North Sumatra	Medan	Chicken	NA
 EPI123594|A/Chicken/Langkat/BBPV1-576/2005, EPI123592|A/Chicken/Langkat/BBPV1-576/2005	A/Chicken/Langkat/BBPV1-576/2005	avian_flu	EPI_ISL_13283	2005-11-25	Asia	Indonesia	NA	NA	Chicken	NA
 EPI123591|A/Chicken/Medan/BBPV1-576/2005	A/Chicken/Medan/BBPV1-576/2005	avian_flu	EPI_ISL_13282	2005-10-13	Asia	Indonesia	North Sumatra	Medan	Chicken	NA
 EPI123590|A/Chicken/Medan/BBPV1-571/2005	A/Chicken/Medan/BBPV1-571/2005	avian_flu	EPI_ISL_13281	2005-10-12	Asia	Indonesia	North Sumatra	Medan	Chicken	NA
-EPI123539|A/Chicken/Indonesia/Wates83/2005	A/Chicken/Indonesia/Wates83/2005	avian_flu	EPI_ISL_13261	NA	Asia	Indonesia	NA	NA	Chicken	NA
 EPI123537|A/Chicken/Indonesia/Wates126/2005	A/Chicken/Indonesia/Wates126/2005	avian_flu	EPI_ISL_13260	NA	Asia	Indonesia	NA	NA	Chicken	NA
-EPI123535|A/Chicken/Indonesia/Wates80/2005	A/Chicken/Indonesia/Wates80/2005	avian_flu	EPI_ISL_13259	NA	Asia	Indonesia	NA	NA	Chicken	NA
-EPI123533|A/Chicken/Indonesia/Wates77/2005	A/Chicken/Indonesia/Wates77/2005	avian_flu	EPI_ISL_13258	NA	Asia	Indonesia	NA	NA	Chicken	NA
-EPI123531|A/Chicken/Indonesia/Wates130/2005	A/Chicken/Indonesia/Wates130/2005	avian_flu	EPI_ISL_13257	NA	Asia	Indonesia	NA	NA	Chicken	NA
 EPI123529|A/Chicken/Indonesia/Wates1/2005	A/Chicken/Indonesia/Wates1/2005	avian_flu	EPI_ISL_13256	NA	Asia	Indonesia	NA	NA	Chicken	NA
 EPI123402|A/chicken/Vietnam/TY25/2005	A/chicken/Vietnam/TY25/2005	avian_flu	EPI_ISL_13226	NA	Asia	Vietnam	NA	NA	Chicken	NA
 EPI123400|A/chicken/Vietnam/TY9/2005	A/chicken/Vietnam/TY9/2005	avian_flu	EPI_ISL_13225	NA	Asia	Vietnam	NA	NA	Chicken	NA
@@ -22427,7 +21975,6 @@ EPI335085|A/duck/Lao/986/2010	A/duck/Lao/986/2010	avian_flu	EPI_ISL_95811	NA	Asi
 EPI335077|A/duck/Lao/987/2010	A/duck/Lao/987/2010	avian_flu	EPI_ISL_95810	NA	Asia	Lao, People's Democratic Republic	NA	NA	Duck	NA
 EPI332570|A/duck/Shandong/009/2008	A/duck/Shandong/009/2008	avian_flu	EPI_ISL_95061	2008-12-15	Asia	China	NA	NA	Duck	NA
 EPI331853|A/wood duck/Ohio/623/2004	A/wood duck/Ohio/623/2004	avian_flu	EPI_ISL_94926	NA	North America	United States	NA	NA	Duck	NA
-EPI330995|2011766365_195934_v1_4	A/duck/Vietnam/NCVD-672/2011	avian_flu	EPI_ISL_94673	NA	Asia	Vietnam	Tinh Nam Dinh	Nam Dinh	Duck	NA
 NA	A/duck/Viet Nam/41ST/2008	avian_flu	EPI_ISL_63029	NA	Asia	Vietnam	NA	NA	Duck	NA
 EPI184220|A/duck/Viet Nam/38ST/2008	A/duck/Viet Nam/38ST/2008	avian_flu	EPI_ISL_63028	NA	Asia	Vietnam	NA	NA	Duck	NA
 EPI184219|A/duck/Viet Nam/36ST/2008	A/duck/Viet Nam/36ST/2008	avian_flu	EPI_ISL_63027	NA	Asia	Vietnam	NA	NA	Duck	NA
@@ -22440,7 +21987,6 @@ EPI219355|A/rubby shelduck/Mongolia/X63/2009	A/rubby shelduck/Mongolia/X63/2009	
 EPI219350|A/rubby shelduck/Mongolia/X42/2009	A/rubby shelduck/Mongolia/X42/2009	avian_flu	EPI_ISL_62731	NA	Asia	Mongolia	NA	NA	Duck	NA
 EPI300764|A/common goldeneye/Mongolia/X59/2009, EPI219321|A/common goldeneye/Mongolia/X59/2009	A/common goldeneye/Mongolia/X59/2009	avian_flu	EPI_ISL_62724	NA	Asia	Mongolia	NA	NA	Duck	NA
 EPI174641|A/duck/Hunan/689/2006	A/duck/Hunan/689/2006	avian_flu	EPI_ISL_29174	2006-12-15	Asia	China	Hunan Province	NA	Duck	NA
-EPI127776|A/duck/Egypt/5169-1/2007	A/duck/Egypt/5169-1/2007	avian_flu	EPI_ISL_14134	NA	Africa	Egypt	NA	NA	Duck	NA
 EPI127756|A/duck/Egypt/9399NAMRU3-CLEVB202/2007	A/duck/Egypt/9399NAMRU3-CLEVB202/2007	avian_flu	EPI_ISL_14124	NA	Africa	Egypt	NA	NA	Duck	NA
 EPI127718|A/duck/Egypt/3048NAMRU3-CLEVB74/2007	A/duck/Egypt/3048NAMRU3-CLEVB74/2007	avian_flu	EPI_ISL_14105	NA	Africa	Egypt	NA	NA	Duck	NA
 EPI127716|A/duck/Egypt/3047NAMRU3-CLEVB63/2007	A/duck/Egypt/3047NAMRU3-CLEVB63/2007	avian_flu	EPI_ISL_14104	NA	Africa	Egypt	NA	NA	Duck	NA
@@ -22488,7 +22034,6 @@ EPI389930|A/duck/Vietnam/LBM136/2012	A/duck/Vietnam/LBM136/2012	avian_flu	EPI_IS
 EPI389922|A/duck/Vietnam/LBM133/2012	A/duck/Vietnam/LBM133/2012	avian_flu	EPI_ISL_127576	2012-03-07	Asia	Vietnam	NA	NA	Anas platyrhynchos	NA
 EPI389914|A/duck/Vietnam/LBM132/2012	A/duck/Vietnam/LBM132/2012	avian_flu	EPI_ISL_127575	2012-03-07	Asia	Vietnam	NA	NA	Anas platyrhynchos	NA
 EPI334000|A/mallard/Wisconsin/2576/2009	A/mallard/Wisconsin/2576/2009	avian_flu	EPI_ISL_95417	2009-10-06	North America	United States	NA	NA	Anas platyrhynchos	NA
-EPI331854|A/mallard/Maryland/802/2007	A/mallard/Maryland/802/2007	avian_flu	EPI_ISL_94927	2007-08-18	North America	United States	NA	NA	Anas platyrhynchos	NA
 EPI219340|A/mallard/Hokkaido/24/2009	A/mallard/Hokkaido/24/2009	avian_flu	EPI_ISL_62729	NA	Asia	Japan	NA	NA	Anas platyrhynchos	NA
 NA	A/mallard/Sweden/2724/06	avian_flu	EPI_ISL_13251	NA	Europe	Sweden	NA	NA	Anas platyrhynchos	NA
 EPI120042|A/mallard/Switzerland/V558/2006	A/mallard/Switzerland/V558/2006	avian_flu	EPI_ISL_12829	NA	Europe	Switzerland	NA	NA	Anas platyrhynchos	NA
@@ -22590,7 +22135,6 @@ EPI224611|A/Cygnus olor/BIH/1/2006	A/Cygnus olor/BIH/1/2006	avian_flu	EPI_ISL_64
 NA	A/mute swan/Czech Republic/7208/2006	avian_flu	EPI_ISL_64012	2006-04-11	Europe	Czech Republic	NA	NA	Cygnus olor	NA
 NA	A/mute swan/Czech Republic/6461/2006	avian_flu	EPI_ISL_64011	2006-04-04	Europe	Czech Republic	NA	NA	Cygnus olor	NA
 NA	A/mute swan/Czech Republic/10662/2006	avian_flu	EPI_ISL_64010	2006-05-18	Europe	Czech Republic	NA	NA	Cygnus olor	NA
-EPI14332|A/mute_swan/France/06303/2006	A/mute swan/France/06303/2006	avian_flu	EPI_ISL_15044	NA	Europe	France	NA	NA	Cygnus olor	NA
 EPI2140721|A/turkey/Italy/21VIR10970-3/2021_HA	A/turkey/Italy/21VIR10970-3/2021	avian_flu	EPI_ISL_14760703	2021-12-09	Europe	Italy	NA	NA	Turkey	NA
 EPI2140712|A/turkey/Italy/21VIR10847-1/2021_HA	A/turkey/Italy/21VIR10847-1/2021	avian_flu	EPI_ISL_14760702	2021-12-08	Europe	Italy	NA	NA	Turkey	NA
 EPI2140695|A/turkey/Italy/21VIR10757-1/2021_HA	A/turkey/Italy/21VIR10757-1/2021	avian_flu	EPI_ISL_14760700	2021-12-07	Europe	Italy	NA	NA	Turkey	NA
@@ -22699,7 +22243,6 @@ EPI1789412|A/European bee-eater/Kazakhstan/7a/2007	A/European bee-eater/Kazakhst
 EPI1789411|A/starling/Kostanay/233/2007	A/starling/Kostanay/233/2007	avian_flu	EPI_ISL_505774	2007-06-22	Asia	Kazakhstan	Kostanay	NA	Other avian	NA
 EPI395460|A/little grebe/Miyazaki/22M718/2011	A/little grebe/Miyazaki/22M718/2011	avian_flu	EPI_ISL_129226	2011-02-08	Asia	Japan	Miyazaki	NA	Other avian	NA
 EPI395409|A/grey heron/Oita/4402B069/2011	A/grey heron/Oita/4402B069/2011	avian_flu	EPI_ISL_129212	2011-02-15	Asia	Japan	Oita	NA	Other avian	NA
-EPI224760|A/Quail/Central Java/SMRG/2006	A/Quail/Central Java/SMRG/2006	avian_flu	EPI_ISL_64213	2006-06-01	Asia	Indonesia	Central Java	NA	Other avian	NA
 EPI224497|A/wood duck/Ohio/423/2004	A/wood duck/Ohio/423/2004	avian_flu	EPI_ISL_64008	NA	North America	United States	Ohio	NA	Other avian	NA
 EPI222873|A/tree sparrow/Jiangsu/1/2008	A/tree sparrow/Jiangsu/1/2008	avian_flu	EPI_ISL_63711	NA	Asia	China	NA	NA	Other avian	NA
 EPI221860|A/crow/Peshawer/NARC7914/2007	A/crow/Peshawer/NARC7914/2007	avian_flu	EPI_ISL_63472	NA	Asia	Pakistan	NA	NA	Other avian	NA
@@ -22737,18 +22280,6 @@ EPI337247|A/water/Hebei/2/2009	A/water/Hebei/2/2009	avian_flu	EPI_ISL_96898	2009
 EPI337239|A/water/Hebei/1/2009	A/water/Hebei/1/2009	avian_flu	EPI_ISL_96897	2009-01-06	Asia	China	NA	NA	Environment	NA
 EPI283786|A/environment/Egypt/105swf/2010	A/environment/Egypt/105swf/2010	avian_flu	EPI_ISL_80425	NA	Africa	Egypt	NA	NA	Environment	NA
 EPI283785|A/environment/Egypt/104swf/2010	A/environment/Egypt/104swf/2010	avian_flu	EPI_ISL_80424	NA	Africa	Egypt	NA	NA	Environment	NA
-EPI280280|A/water/Hunan/7/2009.4	A/water/Hunan/7/2009	avian_flu	EPI_ISL_79700	2009-01-16	Asia	China	Hunan	NA	Environment	NA
-EPI280272|A/water/Hunan/3/2009.4	A/water/Hunan/3/2009	avian_flu	EPI_ISL_79699	2009-01-16	Asia	China	Hunan	NA	Environment	NA
-EPI280264|A/environment/Xinjiang/6/2009.4	A/environment/Xinjiang/6/2009	avian_flu	EPI_ISL_79698	2009-01-16	Asia	China	Xinjiang	NA	Environment	NA
-EPI280256|A/water/Xinjiang/3/2009.4	A/water/Xinjiang/3/2009	avian_flu	EPI_ISL_79697	2009-01-16	Asia	China	Xinjiang	NA	Environment	NA
-EPI280248|A/environment/Guizhou/9/2009.4	A/environment/Guizhou/9/2009	avian_flu	EPI_ISL_79696	2009-01-16	Asia	China	Guizhou	NA	Environment	NA
-EPI280240|A/environment/Guizhou/7/2009.4	A/environment/Guizhou/7/2009	avian_flu	EPI_ISL_79695	2009-01-16	Asia	China	Guizhou	NA	Environment	NA
-EPI280232|A/environment/Guizhou/4/2009.4	A/environment/Guizhou/4/2009	avian_flu	EPI_ISL_79694	2009-01-16	Asia	China	Guizhou	NA	Environment	NA
-EPI280224|A/environment/Guizhou/2/2009.4	A/environment/Guizhou/2/2009	avian_flu	EPI_ISL_79693	2009-01-16	Asia	China	Guizhou	NA	Environment	NA
-EPI280216|A/duck_feces/Hebei/5/2009.4	A/duck feces/Hebei/5/2009	avian_flu	EPI_ISL_79692	2009-01-06	Asia	China	Hubei	NA	Environment	NA
-EPI280208|A/water/Hebei/3/2009.4	A/water/Hebei/3/2009	avian_flu	EPI_ISL_79691	2009-01-06	Asia	China	Hubei	NA	Environment	NA
-EPI280200|A/water/Hebei/2/2009.4	A/water/Hebei/2/2009	avian_flu	EPI_ISL_79690	2009-01-06	Asia	China	Hubei	NA	Environment	NA
-EPI280192|A/water/Hebei/1/2009.4	A/water/Hebei/1/2009	avian_flu	EPI_ISL_79689	2009-01-06	Asia	China	Hubei	NA	Environment	NA
 EPI222034|A/environment/Hunan/5-32/2007	A/environment/Hunan/5-32/2007	avian_flu	EPI_ISL_63502	NA	Asia	China	NA	NA	Environment	NA
 EPI222026|A/environment/Hunan/5-25/2007	A/environment/Hunan/5-25/2007	avian_flu	EPI_ISL_63501	NA	Asia	China	NA	NA	Environment	NA
 EPI222018|A/environment/Hunan/2-16/2007	A/environment/Hunan/2-16/2007	avian_flu	EPI_ISL_63500	NA	Asia	China	NA	NA	Environment	NA
@@ -22759,69 +22290,21 @@ EPI221986|A/environment/Hunan/1-12/2007	A/environment/Hunan/1-12/2007	avian_flu	
 EPI221982|A/water/Dongting Lake/Hunan/5-41/2007	A/water/Dongting Lake/Hunan/5-41/2007	avian_flu	EPI_ISL_63495	2007-10-31	Asia	China	NA	NA	Water sample	NA
 EPI587514|A/environment/Cambodia/E772W23M1/2013	A/environment/Cambodia/E772W23M1/2013	avian_flu	EPI_ISL_178248	2013-06-03	Asia	Cambodia	Khett Takev	NA	Other environment	NA
 EPI1930828|A/Hawk/Turkey/11/2006	A/Hawk/Turkey/11/2006	avian_flu	EPI_ISL_6781413	NA	Asia	Turkey	NA	NA	Host	NA
-EPI639614|2014702172_245951_v1_4	A/Vietnam/VP39/2013	avian_flu	EPI_ISL_195245	2013-11-15	Asia	Vietnam	NA	NA	Human	NA
-EPI639606|2014702171_245955_v1_4	A/Vietnam/C076H/2012	avian_flu	EPI_ISL_195244	2012-02-23	Asia	Vietnam	NA	NA	Human	NA
 EPI531332|A/Cambodia/X1024307/2013	A/Cambodia/X1024307/2013	avian_flu	EPI_ISL_162429	2013-10-22	Asia	Cambodia	NA	NA	Human	NA
 EPI531324|A/Cambodia/X0916322/2013	A/Cambodia/X0916322/2013	avian_flu	EPI_ISL_162428	2013-09-16	Asia	Cambodia	NA	NA	Human	NA
 EPI531316|A/Cambodia/X0913301/2013	A/Cambodia/X0913301/2013	avian_flu	EPI_ISL_162427	2013-09-13	Asia	Cambodia	NA	NA	Human	NA
-EPI531306|A/Cambodia/X0810301/2013	A/Cambodia/X0810301/2013	avian_flu	EPI_ISL_162426	2013-08-09	Asia	Cambodia	NA	NA	Human	NA
-EPI531302|A/Cambodia/X0828324/2013	A/Cambodia/X0828324/2013	avian_flu	EPI_ISL_162425	2013-02-28	Asia	Cambodia	NA	NA	Human	NA
-EPI531294|A/Cambodia/X0817302/2013	A/Cambodia/X0817302/2013	avian_flu	EPI_ISL_162424	2013-08-16	Asia	Cambodia	NA	NA	Human	NA
 EPI531274|A/Cambodia/X0808305/2013	A/Cambodia/X0808305/2013	avian_flu	EPI_ISL_162420	2013-07-08	Asia	Cambodia	NA	NA	Human	NA
 EPI531266|A/Cambodia/X0628313/2013	A/Cambodia/X0628313/2013	avian_flu	EPI_ISL_162419	2013-06-28	Asia	Cambodia	NA	NA	Human	NA
-EPI337231|A/Hubei/1/2010	A/Hubei/1/2010	avian_flu	EPI_ISL_96896	2010-05-21	Asia	China	NA	NA	Human	NA
-EPI337224|A/Hunan/2/2009	A/Hunan/2/2009	avian_flu	EPI_ISL_96895	2009-01-23	Asia	China	NA	NA	Human	NA
-EPI337217|A/Guangxi/1/2009	A/Guangxi/1/2009	avian_flu	EPI_ISL_96894	2009-01-19	Asia	China	NA	NA	Human	NA
-EPI337210|A/Guizhou/1/2009	A/Guizhou/1/2009	avian_flu	EPI_ISL_96893	2009-01-15	Asia	China	NA	NA	Human	NA
-EPI337203|A/Xinjiang/1/2009	A/Xinjiang/1/2009	avian_flu	EPI_ISL_96892	2009-01-10	Asia	China	NA	NA	Human	NA
-EPI337196|A/Hunan/1/2009	A/Hunan/1/2009	avian_flu	EPI_ISL_96891	2009-01-08	Asia	China	NA	NA	Human	NA
-EPI337189|A/Shandong/1/2009	A/Shandong/1/2009	avian_flu	EPI_ISL_96890	2009-01-05	Asia	China	NA	NA	Human	NA
-EPI337182|A/Beijing/1/2009	A/Beijing/1/2009	avian_flu	EPI_ISL_96889	2008-12-04	Asia	China	NA	NA	Human	NA
-EPI337175|A/Guangdong/1/2008	A/Guangdong/1/2008	avian_flu	EPI_ISL_96888	2008-02-16	Asia	China	NA	NA	Human	NA
-EPI337168|A/Guangxi/1/2008	A/Guangxi/1/2008	avian_flu	EPI_ISL_96887	2008-02-12	Asia	China	NA	NA	Human	NA
-EPI337161|A/Hunan/1/2008	A/Hunan/1/2008	avian_flu	EPI_ISL_96886	2008-01-16	Asia	China	NA	NA	Human	NA
-EPI337154|A/Anhui/1/2007	A/Anhui/1/2007	avian_flu	EPI_ISL_96885	2007-03-17	Asia	China	NA	NA	Human	NA
-NA	A/Fujian/1/2007	avian_flu	EPI_ISL_96884	2007-02-18	Asia	China	NA	NA	Human	NA
-EPI337141|A/Anhui/1/2006	A/Anhui/1/2006	avian_flu	EPI_ISL_96883	2006-12-10	Asia	China	NA	NA	Human	NA
-NA	A/Xinjiang/1/2006	avian_flu	EPI_ISL_96882	2006-06-19	Asia	China	NA	NA	Human	NA
-EPI337128|A/Guangdong/2/2006	A/Guangdong/2/2006	avian_flu	EPI_ISL_96881	2006-06-03	Asia	China	NA	NA	Human	NA
-EPI337121|A/Sichuan/3/2006	A/Sichuan/3/2006	avian_flu	EPI_ISL_96880	2006-04-16	Asia	China	NA	NA	Human	NA
-EPI337114|A/Hubei/1/2006	A/Hubei/1/2006	avian_flu	EPI_ISL_96879	2006-04-01	Asia	China	NA	NA	Human	NA
-EPI337107|A/Shanghai/1/2006	A/Shanghai/1/2006	avian_flu	EPI_ISL_96878	2006-03-13	Asia	China	NA	NA	Human	NA
-NA	A/Guangdong/1/2006	avian_flu	EPI_ISL_96877	2006-02-22	Asia	China	NA	NA	Human	NA
-NA	A/Zhejiang/1/2006	avian_flu	EPI_ISL_96876	2006-02-10	Asia	China	NA	NA	Human	NA
-NA	A/Hunan/1/2006	avian_flu	EPI_ISL_96875	2006-01-27	Asia	China	NA	NA	Human	NA
-NA	A/Sichuan/1/2006	avian_flu	EPI_ISL_96874	2006-01-03	Asia	China	NA	NA	Human	NA
-EPI337076|A/Sichuan/2/2006	A/Sichuan/2/2006	avian_flu	EPI_ISL_96873	2006-01-10	Asia	China	NA	NA	Human	NA
-NA	A/Fujian/1/2005	avian_flu	EPI_ISL_96872	2005-12-06	Asia	China	NA	NA	Human	NA
-NA	A/Anhui/2/2005	avian_flu	EPI_ISL_96871	2005-11-11	Asia	China	NA	NA	Human	NA
-NA	A/Anhui/1/2005	avian_flu	EPI_ISL_96870	2005-11-01	Asia	China	NA	NA	Human	NA
 EPI284096|A/Vietnam/HN31244/2007	A/Vietnam/HN31244/2007	avian_flu	EPI_ISL_80504	NA	Asia	Vietnam	NA	NA	Human	NA
 EPI284001|A/Cambodia/S1211394/2008	A/Cambodia/S1211394/2008	avian_flu	EPI_ISL_80494	2008-12-11	Asia	Cambodia	NA	NA	Human	NA
-NA	A/Cambodia/R0405050/2007	avian_flu	EPI_ISL_80488	2007-04-04	Asia	Cambodia	NA	NA	Human	NA
 EPI283871|A/Cambodia/VN05-103/2005	A/Cambodia/VN05-103/2005	avian_flu	EPI_ISL_80472	2005-04-19	Asia	Cambodia	NA	NA	Human	NA
 EPI283867|A/Cambodia/P0322095/2005	A/Cambodia/P0322095/2005	avian_flu	EPI_ISL_80471	2005-03-22	Asia	Cambodia	NA	NA	Human	NA
 EPI283832|A/Cambodia/Q0405047/2006	A/Cambodia/Q0405047/2006	avian_flu	EPI_ISL_80466	2006-04-04	Asia	Cambodia	NA	NA	Human	NA
 EPI283826|A/Cambodia/Q0321176/2006	A/Cambodia/Q0321176/2006	avian_flu	EPI_ISL_80465	2006-03-21	Asia	Cambodia	NA	NA	Human	NA
-EPI280176|A/Hunan/2/2009.4	A/Hunan/2/2009	avian_flu	EPI_ISL_79687	2009-01-23	Asia	China	Hunan	NA	Human	NA
-EPI280168|A/Hunan/1/2009.4	A/Hunan/1/2009	avian_flu	EPI_ISL_79686	2009-01-08	Asia	China	Hunan	NA	Human	NA
-EPI280160|A/Beijing/1/2009.4	A/Beijing/1/2009	avian_flu	EPI_ISL_79685	2008-12-04	Asia	China	Beijing	NA	Human	NA
 EPI280152|A/Jiangsu/2/2007.4	A/Jiangsu/2/2007	avian_flu	EPI_ISL_79684	2007-12-03	Asia	China	Jiangsu	NA	Human	NA
 EPI280144|A/Jiangsu/1/2007.4	A/Jiangsu/1/2007	avian_flu	EPI_ISL_79683	2007-11-24	Asia	China	Jiangsu	NA	Human	NA
-EPI280136|A/Fujian/1/2007.4	A/Fujian/1/2007	avian_flu	EPI_ISL_79682	2007-02-18	Asia	China	Fujian	NA	Human	NA
-EPI280128|A/Xinjiang/1/2006.4	A/Xinjiang/1/2006	avian_flu	EPI_ISL_79681	2006-06-19	Asia	China	Xinjiang	NA	Human	NA
-EPI280120|A/Hubei/1/2006.4	A/Hubei/1/2006	avian_flu	EPI_ISL_79680	2006-04-01	Asia	China	Hubei	NA	Human	NA
-EPI224777|A/Shanghai/1/2006	A/Shanghai/1/2006	avian_flu	EPI_ISL_64227	NA	Asia	China	NA	NA	Human	NA
 EPI224609|A/China/2006	A/China/2006	avian_flu	EPI_ISL_64081	NA	Asia	China	NA	NA	Human	NA
 EPI181392|A/Vietnam/1194/2004, EPI181391|A/Vietnam/1194/2004	A/Vietnam/1194/2004	avian_flu	EPI_ISL_30632	NA	Asia	Vietnam	NA	NA	Human	NA
-EPI181303|A/Xinjiang/1/2006	A/Xinjiang/1/2006	avian_flu	EPI_ISL_30608	2006-07-02	Asia	China	Xinjiang Uyghur Autonomous Region	NA	Human	NA
-EPI181302|A/Jiangxi/1/2005	A/Jiangxi/1/2005	avian_flu	EPI_ISL_30607	2005-12-10	Asia	China	Jiangxi Province	NA	Human	NA
-EPI181301|A/Guangdong/1/2006	A/Guangdong/1/2006	avian_flu	EPI_ISL_30606	2006-03-04	Asia	China	Guangdong Province	NA	Human	NA
-EPI181300|A/Fujian/1/2007	A/Fujian/1/2007	avian_flu	EPI_ISL_30605	2007-02-25	Asia	China	Fujian Province	NA	Human	NA
-EPI181299|A/Fujian/1/2005	A/Fujian/1/2005	avian_flu	EPI_ISL_30604	2005-12-12	Asia	China	Fujian Province	NA	Human	NA
-EPI181298|A/Sichuan/1/2006	A/Sichuan/1/2006	avian_flu	EPI_ISL_30603	2006-01-11	Asia	China	Sichuan Province	NA	Human	NA
-EPI181297|A/Zhejiang/1/2006	A/Zhejiang/1/2006	avian_flu	EPI_ISL_30602	2006-02-21	Asia	China	Zhejiang Province	NA	Human	NA
-EPI181296|A/Hunan/1/2006	A/Hunan/1/2006	avian_flu	EPI_ISL_30601	2006-02-04	Asia	China	Hunan Province	NA	Human	NA
 EPI2506560|A/guinea_fowl/Nigeria/VRD-21-169_21VIR7423-21/2021_HA	A/guinea_fowl/Nigeria/VRD-21-169_21VIR7423-21/2021	avian_flu	EPI_ISL_17414668	2021-03-21	Africa	Nigeria	Gombe State	NA	Avian	NA
 EPI2506100|A/avian/Nigeria/VRD-21-181_21VIR7423-2/2021_HA	A/avian/Nigeria/VRD-21-181_21VIR7423-2/2021	avian_flu	EPI_ISL_17414610	2021-03-23	Africa	Nigeria	Katsina State	NA	Avian	NA
 EPI2506092|A/avian/Nigeria/VRD-21-174_21VIR7423-22/2021_HA	A/avian/Nigeria/VRD-21-174_21VIR7423-22/2021	avian_flu	EPI_ISL_17414609	2021-03-21	Africa	Nigeria	Nasarawa State	NA	Avian	NA
@@ -22857,15 +22340,9 @@ EPI284480|2008750203	A/chicken/Vietnam/NCVD-084/2008	avian_flu	EPI_ISL_80645	NA	
 EPI284479|2008750202	A/chicken/Vietnam/NCVD-083/2008	avian_flu	EPI_ISL_80644	NA	Asia	Vietnam	LAO CAI	NA	Avian	NA
 EPI284478|2008750200	A/chicken/Vietnam/NCVD-081/2008	avian_flu	EPI_ISL_80643	NA	Asia	Vietnam	LAO CAI	NA	Avian	NA
 EPI284477|2008750199	A/chicken/Vietnam/NCVD-080/2008	avian_flu	EPI_ISL_80642	NA	Asia	Vietnam	LAO CAI	NA	Avian	NA
-EPI284476|2008750197	A/chicken/Vietnam/NCVD-093/2008	avian_flu	EPI_ISL_80641	NA	Asia	Vietnam	LANG SON	NA	Avian	NA
-EPI284475|2008750172	A/chicken/Vietnam/NCVD-05/2008	avian_flu	EPI_ISL_80640	NA	Asia	Vietnam	LANG SON	NA	Avian	NA
-EPI284474|2008750171	A/chicken/Vietnam/NCVD-04/2008	avian_flu	EPI_ISL_80639	NA	Asia	Vietnam	LANG SON	NA	Avian	NA
-EPI284473|2008750170	A/chicken/Vietnam/NCVD-03/2008	avian_flu	EPI_ISL_80638	NA	Asia	Vietnam	LANG SON	NA	Avian	NA
 EPI284472|2009713357	A/chicken/Vietnam/NCVD-296/2009	avian_flu	EPI_ISL_80637	NA	Asia	Vietnam	NA	NA	Avian	NA
 EPI284471|2009713356	A/chicken/Vietnam/NCVD-295/2009	avian_flu	EPI_ISL_80636	NA	Asia	Vietnam	NA	NA	Avian	NA
-EPI284470|2010729149	A/chicken/Vietnam/NCVD-421/2010	avian_flu	EPI_ISL_80635	NA	Asia	Vietnam	Nghe An	NA	Avian	NA
 EPI284469|2010729127	A/chicken/Vietnam/NCVD-399/2010	avian_flu	EPI_ISL_80634	NA	Asia	Vietnam	Ha Giang	NA	Avian	NA
-EPI284468|2010729126	A/chicken/Vietnam/NCVD-398/2010	avian_flu	EPI_ISL_80633	NA	Asia	Vietnam	Ha Giang	NA	Avian	NA
 EPI284467|2010729128	A/chicken/Vietnam/NCVD-400/2010	avian_flu	EPI_ISL_80632	NA	Asia	Vietnam	Bac Ninh	NA	Avian	NA
 EPI284466|2009713343	A/chicken/Vietnam/NCVD-279/2009	avian_flu	EPI_ISL_80631	NA	Asia	Vietnam	NA	NA	Avian	NA
 EPI284465|2010729125	A/chicken/Vietnam/NCVD-397/2010	avian_flu	EPI_ISL_80630	NA	Asia	Vietnam	Ninh Binh	NA	Avian	NA
@@ -22882,9 +22359,7 @@ EPI284455|2009713346	A/chicken/Vietnam/NCVD-282/2009	avian_flu	EPI_ISL_80620	NA	
 EPI284454|2009713345	A/chicken/Vietnam/NCVD-281/2009	avian_flu	EPI_ISL_80619	NA	Asia	Vietnam	NA	NA	Avian	NA
 EPI284453|2009713340	A/chicken/Vietnam/NCVD-swab276/2008	avian_flu	EPI_ISL_80618	NA	Asia	Vietnam	NA	NA	Avian	NA
 EPI284452|2009716399	A/chicken/Vietnam/NCVD-188/2008	avian_flu	EPI_ISL_80617	NA	Asia	Vietnam	QUANG NGAI	NA	Avian	NA
-EPI284451|2009716396	A/chicken/Vietnam/NCVD-185/2008	avian_flu	EPI_ISL_80616	NA	Asia	Vietnam	QUANG NGAI	NA	Avian	NA
 EPI284450|2009716385	A/chicken/Vietnam/NCVD-138/2008	avian_flu	EPI_ISL_80615	NA	Asia	Vietnam	QUANG NGAI	NA	Avian	NA
-EPI284449|2009716375	A/chicken/Vietnam/NCVD-117/2008	avian_flu	EPI_ISL_80614	NA	Asia	Vietnam	KIEN GIANG	NA	Avian	NA
 EPI284448|2010729140	A/chicken/Vietnam/NCVD-412/2010	avian_flu	EPI_ISL_80613	NA	Asia	Vietnam	Bac Kan	NA	Avian	NA
 EPI284447|2010729138	A/chicken/Vietnam/NCVD-410/2010	avian_flu	EPI_ISL_80612	NA	Asia	Vietnam	Bac Kan	NA	Avian	NA
 EPI284446|2010729137	A/chicken/Vietnam/NCVD-409/2010	avian_flu	EPI_ISL_80611	NA	Asia	Vietnam	Bac Kan	NA	Avian	NA
@@ -23001,7 +22476,6 @@ EPI2139504|A/chicken/Italy/21VIR9219-6/2021_HA	A/chicken/Italy/21VIR9219-6/2021	
 EPI2139464|A/chicken/Italy/21VIR9212-1/2021_HA	A/chicken/Italy/21VIR9212-1/2021	avian_flu	EPI_ISL_14760552	2021-11-05	Europe	Italy	NA	NA	Chicken	NA
 EPI2139448|A/chicken/Italy/21VIR9133-21/2021_HA	A/chicken/Italy/21VIR9133-21/2021	avian_flu	EPI_ISL_14760550	2021-11-04	Europe	Italy	NA	NA	Chicken	NA
 EPI2139432|A/chicken/Italy/21VIR9074-10/2021_HA	A/chicken/Italy/21VIR9074-10/2021	avian_flu	EPI_ISL_14760548	2021-11-02	Europe	Italy	NA	NA	Chicken	NA
-EPI2580433|A/chicken/Egypt/S75/2015	A/chicken/Egypt/S75/2015	avian_flu	EPI_ISL_6781664	NA	Africa	Egypt	NA	NA	Chicken	NA
 EPI1930838|A/chicken/Turkey/27/2006	A/chicken/Turkey/27/2006	avian_flu	EPI_ISL_6781423	NA	Asia	Turkey	NA	NA	Chicken	NA
 EPI1930837|A/chicken/Turkey/26/2006	A/chicken/Turkey/26/2006	avian_flu	EPI_ISL_6781422	NA	Asia	Turkey	NA	NA	Chicken	NA
 EPI1930835|A/chicken/Turkey/25/2006	A/chicken/Turkey/25/2006	avian_flu	EPI_ISL_6781420	NA	Asia	Turkey	NA	NA	Chicken	NA
@@ -23017,7 +22491,6 @@ EPI1930823|A/chicken/Turkey/2/2006	A/chicken/Turkey/2/2006	avian_flu	EPI_ISL_678
 EPI1930822|A/chicken/Turkey/1/2006	A/chicken/Turkey/1/2006	avian_flu	EPI_ISL_6781407	NA	Asia	Turkey	NA	NA	Chicken	NA
 EPI1896085|A/chicken/Nigeria/VRD21-98_21VIR2288-6/2021	A/chicken/Nigeria/VRD21-98_21VIR2288-6/2021	avian_flu	EPI_ISL_4061491	2021-02-12	Africa	Nigeria	NA	NA	Chicken	NA
 NA	A/chicken/Nigeria/VRD21-37_21VIR2288-2/2021	avian_flu	EPI_ISL_4061487	2021-02-05	Africa	Nigeria	NA	NA	Chicken	NA
-EPI1896075|A/chicken/Nigeria/VRD21-37_21VIR2288-2/2021	A/chicken/Nigeria/VRD21-37_21VIR2288-2/2021	avian_flu	EPI_ISL_4061486	2021-02-05	Africa	Nigeria	NA	NA	Chicken	NA
 EPI1896066|A/chicken/Nigeria/VRD21-109_21VIR2370-425/2021	A/chicken/Nigeria/VRD21-109_21VIR2370-425/2021	avian_flu	EPI_ISL_4061485	2021-03-01	Africa	Nigeria	NA	NA	Chicken	NA
 EPI1896058|A/chicken/Nigeria/VRD21-102_21VIR2370-424/2021	A/chicken/Nigeria/VRD21-102_21VIR2370-424/2021	avian_flu	EPI_ISL_4061484	2021-03-01	Africa	Nigeria	NA	NA	Chicken	NA
 EPI1866465|A/chicken/Senegal/21VIR1084-5/2021_HA	A/chicken/Senegal/21VIR1084-5/2021	avian_flu	EPI_ISL_2276070	2020-12-23	Africa	Senegal	Region de Thies	NA	Chicken	NA
@@ -23055,10 +22528,7 @@ EPI283988|A/chicken/Cambodia/LC3AL/2007	A/chicken/Cambodia/LC3AL/2007	avian_flu	
 EPI283980|A/chicken/Cambodia/LC1AL/2007	A/chicken/Cambodia/LC1AL/2007	avian_flu	EPI_ISL_80489	2007-09-04	Asia	Cambodia	NA	NA	Chicken	NA
 EPI283967|A/chicken/Cambodia/047LC4/2005	A/chicken/Cambodia/047LC4/2005	avian_flu	EPI_ISL_80487	2005-03-24	Asia	Cambodia	NA	NA	Chicken	NA
 EPI283959|A/chicken/Cambodia/047LC3b/2005	A/chicken/Cambodia/047LC3b/2005	avian_flu	EPI_ISL_80486	2005-03-24	Asia	Cambodia	NA	NA	Chicken	NA
-NA	A/chicken/Cambodia/022LC3b/2005	avian_flu	EPI_ISL_80485	2005-02-09	Asia	Cambodia	NA	NA	Chicken	NA
 EPI283945|A/chicken/Cambodia/022LC1b/2005	A/chicken/Cambodia/022LC1b/2005	avian_flu	EPI_ISL_80484	2005-02-09	Asia	Cambodia	NA	NA	Chicken	NA
-NA	A/chicken/Cambodia/013LC1b/2005	avian_flu	EPI_ISL_80483	2005-02-04	Asia	Cambodia	NA	NA	Chicken	NA
-EPI300863|A/chicken/Cambodia/022LC2b/2005, EPI300792|A/chicken/Cambodia/022LC2b/2005	A/chicken/Cambodia/022LC2b/2005	avian_flu	EPI_ISL_80482	2005-02-09	Asia	Cambodia	NA	NA	Chicken	NA
 EPI300862|A/chicken/Cambodia/013LC2b/2005	A/chicken/Cambodia/013LC2b/2005	avian_flu	EPI_ISL_80481	2005-02-04	Asia	Cambodia	NA	NA	Chicken	NA
 EPI283851|A/chicken/Cambodia/LC/2006	A/chicken/Cambodia/LC/2006	avian_flu	EPI_ISL_80469	2006-03-24	Asia	Cambodia	NA	NA	Chicken	NA
 EPI283825|A/chicken/Egypt/1022L/2010	A/chicken/Egypt/1022L/2010	avian_flu	EPI_ISL_80464	NA	Africa	Egypt	NA	NA	Chicken	NA
@@ -23077,8 +22547,6 @@ EPI283805|A/chicken/Egypt/101604v/2010	A/chicken/Egypt/101604v/2010	avian_flu	EP
 EPI283803|A/chicken/Egypt/1012sf/2010	A/chicken/Egypt/1012sf/2010	avian_flu	EPI_ISL_80442	NA	Africa	Egypt	NA	NA	Chicken	NA
 EPI283802|A/chicken/Egypt/10127s/2010	A/chicken/Egypt/10127s/2010	avian_flu	EPI_ISL_80441	NA	Africa	Egypt	NA	NA	Chicken	NA
 EPI283801|A/chicken/Egypt/1052s/2010	A/chicken/Egypt/1052s/2010	avian_flu	EPI_ISL_80440	NA	Africa	Egypt	NA	NA	Chicken	NA
-EPI283798|A/chicken/Egypt/102d/2010	A/chicken/Egypt/102d/2010	avian_flu	EPI_ISL_80437	NA	Africa	Egypt	NA	NA	Chicken	NA
-EPI283797|A/chicken/Egypt/1063/2010	A/chicken/Egypt/1063/2010	avian_flu	EPI_ISL_80436	NA	Africa	Egypt	NA	NA	Chicken	NA
 EPI283796|A/chicken/Egypt/1055/2010	A/chicken/Egypt/1055/2010	avian_flu	EPI_ISL_80435	2010-02-11	Africa	Egypt	NA	NA	Chicken	NA
 EPI283794|A/chicken/Egypt/1042/2010	A/chicken/Egypt/1042/2010	avian_flu	EPI_ISL_80433	NA	Africa	Egypt	NA	NA	Chicken	NA
 EPI283793|A/chicken/Egypt/1036/2010	A/chicken/Egypt/1036/2010	avian_flu	EPI_ISL_80432	NA	Africa	Egypt	NA	NA	Chicken	NA
@@ -23097,8 +22565,6 @@ NA	A/chicken/Eastern China/JX036/2009	avian_flu	EPI_ISL_80399	NA	Asia	China	NA	N
 EPI283284|A/chicken/Bangladesh/1151-11/2010	A/chicken/Bangladesh/1151-11/2010	avian_flu	EPI_ISL_80268	NA	Asia	Bangladesh	NA	NA	Chicken	NA
 EPI283273|A/chicken/Bangladesh/1151-10/2010	A/chicken/Bangladesh/1151-10/2010	avian_flu	EPI_ISL_80267	NA	Asia	Bangladesh	NA	NA	Chicken	NA
 EPI283268|A/chicken/Bangladesh/1151-9/2010	A/chicken/Bangladesh/1151-9/2010	avian_flu	EPI_ISL_80266	NA	Asia	Bangladesh	NA	NA	Chicken	NA
-EPI224608|A/Chicken/West Java/TASIKSOL/2006	A/Chicken/West Java/TASIKSOL/2006	avian_flu	EPI_ISL_64080	2006-08-01	Asia	Indonesia	NA	NA	Chicken	NA
-EPI224607|A/Chicken/West Java/SMI-PAT/2006	A/Chicken/West Java/SMI-PAT/2006	avian_flu	EPI_ISL_64079	2006-05-01	Asia	Indonesia	NA	NA	Chicken	NA
 EPI224606|A/Chicken/West Java/SMI-CSLK-EC/2006	A/Chicken/West Java/SMI-CSLK-EC/2006	avian_flu	EPI_ISL_64078	NA	Asia	Indonesia	NA	NA	Chicken	NA
 EPI224605|A/Chicken/West Java/PWT-WIJ/2006	A/Chicken/West Java/PWT-WIJ/2006	avian_flu	EPI_ISL_64077	NA	Asia	Indonesia	NA	NA	Chicken	NA
 EPI224604|A/Chicken/West Java/HAMD/2006	A/Chicken/West Java/HAMD/2006	avian_flu	EPI_ISL_64076	2006-05-01	Asia	Indonesia	NA	NA	Chicken	NA
@@ -23107,7 +22573,6 @@ EPI224602|A/Chicken/Way Kanan/BBPVIII/2006	A/Chicken/Way Kanan/BBPVIII/2006	avia
 EPI224601|A/Chicken/Pulau Rampang/BBPVII/2006	A/Chicken/Pulau Rampang/BBPVII/2006	avian_flu	EPI_ISL_64073	NA	Asia	Indonesia	NA	NA	Chicken	NA
 EPI224600|A/Chicken/Padang/BBPVII/2006	A/Chicken/Padang/BBPVII/2006	avian_flu	EPI_ISL_64072	NA	Asia	Indonesia	NA	NA	Chicken	NA
 EPI224599|A/Chicken/Karo/BBPVII/2006	A/Chicken/Karo/BBPVII/2006	avian_flu	EPI_ISL_64071	2006-01-02	Asia	Indonesia	NA	NA	Chicken	NA
-EPI224598|A/Chicken/Gunung Kidul/BBVW/2006	A/Chicken/Gunung Kidul/BBVW/2006	avian_flu	EPI_ISL_64070	NA	Asia	Indonesia	NA	NA	Chicken	NA
 EPI224597|A/Chicken/Bandar Lampung/BBPVIII/2006	A/Chicken/Bandar Lampung/BBPVIII/2006	avian_flu	EPI_ISL_64069	NA	Asia	Indonesia	NA	NA	Chicken	NA
 EPI221829|A/chicken/Romania/TL/nov/2007	A/chicken/Romania/TL/nov/2007	avian_flu	EPI_ISL_63463	NA	Europe	Romania	NA	NA	Chicken	NA
 NA	A/chicken/Indonesia/3/2007	avian_flu	EPI_ISL_63442	NA	Asia	Indonesia	NA	NA	Chicken	NA
@@ -23151,10 +22616,8 @@ EPI182338|A/chicken/Egypt/0837-NLQP/2008	A/chicken/Egypt/0837-NLQP/2008	avian_fl
 EPI182337|A/chicken/Egypt/0831-NLQP/2008	A/chicken/Egypt/0831-NLQP/2008	avian_flu	EPI_ISL_30840	2008-01-10	Africa	Egypt	NA	NA	Chicken	NA
 EPI182336|A/chicken/Egypt/0823-NLQP/2008	A/chicken/Egypt/0823-NLQP/2008	avian_flu	EPI_ISL_30839	2008-01-07	Africa	Egypt	Gharbia	NA	Chicken	NA
 EPI182335|A/chicken/Egypt/0815-NLQP/2008	A/chicken/Egypt/0815-NLQP/2008	avian_flu	EPI_ISL_30838	2008-01-05	Africa	Egypt	NA	NA	Chicken	NA
-EPI182334|A/chicken/Egypt/0813-NLQP/2008	A/chicken/Egypt/0813-NLQP/2008	avian_flu	EPI_ISL_30837	2008-01-04	Africa	Egypt	Gharbia	NA	Chicken	NA
 EPI182332|A/chicken/Egypt/085-NLQP/2008	A/chicken/Egypt/085-NLQP/2008	avian_flu	EPI_ISL_30836	2008-01-03	Africa	Egypt	Alexandria	NA	Chicken	NA
 EPI182329|A/chicken/Egypt/07175-NLQP/2007	A/chicken/Egypt/07175-NLQP/2007	avian_flu	EPI_ISL_30835	2007-05-24	Africa	Egypt	NA	NA	Chicken	NA
-EPI182328|A/chicken/Egypt/07118-NLQP/2007	A/chicken/Egypt/07118-NLQP/2007	avian_flu	EPI_ISL_30834	2007-03-01	Africa	Egypt	NA	NA	Chicken	NA
 EPI182001|A/chicken/Egypt/0891/2008	A/chicken/Egypt/0891/2008	avian_flu	EPI_ISL_30799	2008-09-26	Africa	Egypt	Faiyum	NA	Chicken	NA
 EPI181993|A/chicken/Egypt/0836/2008	A/chicken/Egypt/0836/2008	avian_flu	EPI_ISL_30798	2008-01-15	Africa	Egypt	Qena	Luxor	Chicken	NA
 EPI181640|A/chicken/South_Kalimantan/UT6028/2006	A/chicken/South Kalimantan/UT6028/2006	avian_flu	EPI_ISL_30656	NA	Asia	Indonesia	South Kalimantan	NA	Chicken	NA
@@ -23282,7 +22745,6 @@ EPI283788|A/duck/Egypt/1022/2010	A/duck/Egypt/1022/2010	avian_flu	EPI_ISL_80427	
 EPI283787|A/duck/Egypt/1017/2010	A/duck/Egypt/1017/2010	avian_flu	EPI_ISL_80426	2010-01-18	Africa	Egypt	NA	NA	Duck	NA
 EPI283784|A/duck/Egypt/103swf/2010	A/duck/Egypt/103swf/2010	avian_flu	EPI_ISL_80423	NA	Africa	Egypt	NA	NA	Duck	NA
 NA	A/duck/Eastern China/JS017/2009	avian_flu	EPI_ISL_80403	NA	Asia	China	NA	NA	Duck	NA
-EPI224706|A/Muscovy Duck/Jakarta/HABWIN/2006	A/Muscovy Duck/Jakarta/HABWIN/2006	avian_flu	EPI_ISL_64174	2006-09-01	Asia	Indonesia	NA	NA	Duck	NA
 NA	A/duck/Hungary/11804/2006	avian_flu	EPI_ISL_63778	NA	Europe	Hungary	NA	NA	Duck	NA
 EPI221935|A/duck/Son La/07-33/2007	A/duck/Son La/07-33/2007	avian_flu	EPI_ISL_63491	NA	Asia	Vietnam	NA	NA	Duck	NA
 EPI221934|A/duck/Romania/TL/nov/2007	A/duck/Romania/TL/nov/2007	avian_flu	EPI_ISL_63490	NA	Europe	Romania	NA	NA	Duck	NA
@@ -23351,11 +22813,9 @@ EPI1963000|220112_05_H5N1_Seg4_HA	A/chicken/Rostov-on-Don/159-2V/2021	avian_flu	
 EPI1962992|220112_04_H5N1_Seg4_HA	A/chicken/Rostov-on-Don/159-1V/2021	avian_flu	EPI_ISL_9009296	2021-12-13	Europe	Russian Federation	Rostov Oblast	Rostov-on-Don	Gallus gallus domesticus	NA
 EPI1962984|220112_03_H5N1_Seg4_HA	A/chicken/Stavropol/146-1V/2021	avian_flu	EPI_ISL_9009294	2021-12-02	Europe	Russian Federation	Stavropol Krai	Stavropol	Gallus gallus domesticus	NA
 EPI1962976|220112_02_H5N1_Seg4_HA	A/chicken/Kursk/132-1V/2021	avian_flu	EPI_ISL_9009292	2021-11-27	Europe	Russian Federation	Kursk Oblast	Kursk	Gallus gallus domesticus	NA
-EPI1962968|220112_01_H5N1_Seg4_HA	A/chicken/Kursk/132-1V/2021	avian_flu	EPI_ISL_9009291	2021-11-27	Europe	Russian Federation	Kursk Oblast	Kursk	Gallus gallus domesticus	NA
 EPI1942186|A/Chicken/Sweden/SVA211130SZ0427/FB290424/M-2021	A/Chicken/Sweden/SVA211130SZ0427/FB290424-IP-1/M-2021	avian_flu	EPI_ISL_7452805	2021-11-30	Europe	Sweden	Skane Lan	Skurups Kommun	Gallus gallus domesticus	Domestic
 EPI1930833|A/Pigeon/Turkey/21/2006	A/Pigeon/Turkey/21/2006	avian_flu	EPI_ISL_6781418	NA	Asia	Turkey	NA	NA	Pigeon	NA
 EPI222549|A/ruddy turnstone/DE/509531/2007	A/ruddy turnstone/DE/509531/2007	avian_flu	EPI_ISL_63598	NA	North America	United States	NA	NA	Arenaria interpres	NA
-EPI1921680|A/goose/Czech Republic/18520-1/2021 H5	A/goose/Czech Republic/18520-1/2021	avian_flu	EPI_ISL_5323346	2021-09-27	Europe	Czech Republic	Stredocesky Kraj	Okres Pribram	Anser anser domesticus	Domestic
 EPI1982555|A/greater white-fronted goose/Sweden/SVA211217SZ0323/FB004845/2021	A/greater white-fronted goose/Sweden/SVA211217SZ0323/FB004845/2021	avian_flu	EPI_ISL_9648238	2021-12-16	Europe	Sweden	Kalmar Lan	Torsas Kommun	White-fronted goose	Wild
 EPI222326|A/mountain hawk-eagle/Kumamoto/1/07	A/mountain hawk-eagle/Kumamoto/1/07	avian_flu	EPI_ISL_63564	NA	Asia	Japan	NA	NA	Nisaetus nipalensis	NA
 EPI1949326|A/Turkey/Sweden/SVA211212SZ0001/FB301013-IP2/M-2021	A/Turkey/Sweden/SVA211212SZ0001/FB301013-IP-2/M-2021	avian_flu	EPI_ISL_8338002	2021-12-12	Europe	Sweden	Skane Lan	Skurups Kommun	Meleagris gallopavo	Domestic
@@ -23365,9 +22825,7 @@ EPI2506512|A/goose/Nigeria/VRD-21-293_21VIR7423-26/2021_HA	A/goose/Nigeria/VRD-2
 EPI1863045|A/goose/Netherlands/21028502-002/21028502/2021	A/goose/Netherlands/21028502-002/21028502/2021	avian_flu	EPI_ISL_2227278	2021-05-09	Europe	Netherlands	Provincie Groningen	Houwerzijl	Goose	Wild
 EPI590478|A/goose/Egypt/BSU-NLQP-FY-1/2009	A/goose/Egypt/BSU-NLQP-FY-1/2009	avian_flu	EPI_ISL_179552	2009-04-11	Africa	Egypt	NA	NA	Goose	NA
 EPI338731|A/goose/Egypt/M2794E/2011	A/goose/Egypt/M2794E/2011	avian_flu	EPI_ISL_97212	2011-01-20	Africa	Egypt	NA	NA	Goose	NA
-EPI338613|A/goose/Egypt/M2788A/2011	A/goose/Egypt/M2788A/2011	avian_flu	EPI_ISL_97149	2011-01-20	Africa	Egypt	NA	NA	Goose	NA
 EPI338612|A/goose/Egypt/M2788E/2011	A/goose/Egypt/M2788E/2011	avian_flu	EPI_ISL_97148	2011-01-20	Africa	Egypt	NA	NA	Goose	NA
-EPI338611|A/goose/Egypt/M2794A/2011	A/goose/Egypt/M2794A/2011	avian_flu	EPI_ISL_97147	2011-01-20	Africa	Egypt	NA	NA	Goose	NA
 EPI225792|A/wild goose/Olt/RO-AI-288/2006	A/wild goose/Olt/RO-AI-288/2006	avian_flu	EPI_ISL_64481	NA	Europe	Romania	NA	NA	Goose	Wild
 EPI225791|A/wild goose/Braila/RO-AI-074/2006	A/wild goose/Braila/RO-AI-074/2006	avian_flu	EPI_ISL_64480	NA	Europe	Romania	NA	NA	Goose	Wild
 EPI225131|A/goose/Lahore-Pakistan/NARC-3321/4/2006	A/goose/Lahore-Pakistan/NARC-3321/4/2006	avian_flu	EPI_ISL_64368	NA	Asia	Pakistan	NA	NA	Goose	NA
@@ -23462,7 +22920,6 @@ EPI2140903|A/turkey/Italy/21VIR11006-1/2021_HA	A/turkey/Italy/21VIR11006-1/2021	
 EPI2140869|A/turkey/Italy/21VIR11077-1/2021_HA	A/turkey/Italy/21VIR11077-1/2021	avian_flu	EPI_ISL_14760720	2021-12-10	Europe	Italy	NA	NA	Turkey	NA
 EPI2140764|A/turkey/Italy/21VIR10988-1/2021_HA	A/turkey/Italy/21VIR10988-1/2021	avian_flu	EPI_ISL_14760708	2021-12-09	Europe	Italy	NA	NA	Turkey	NA
 NA	A/turkey/India/10CA04/2012	avian_flu	EPI_ISL_195948	2012-10-19	Asia	India	NA	NA	Turkey	NA
-EPI644376|A/turkey/India/10CA04/2012	A/turkey/India/10CA04/2012	avian_flu	EPI_ISL_195633	2012-10-19	Asia	India	NA	NA	Turkey	NA
 EPI226849|A/Turkey/Langkat/BBPVI/2005	A/Turkey/Langkat/BBPVI/2005	avian_flu	EPI_ISL_64779	NA	Asia	Indonesia	NA	NA	Turkey	NA
 EPI184260|A/turkey/Ontario/84/1983	A/turkey/Ontario/84/1983	avian_flu	EPI_ISL_31540	NA	North America	Canada	Ontario	NA	Turkey	NA
 EPI136765|A/turkey/Egypt/07444S-NLQP/2007	A/turkey/Egypt/07444S-NLQP/2007	avian_flu	EPI_ISL_15710	2007-05-24	Africa	Egypt	NA	NA	Turkey	NA
@@ -23540,30 +22997,19 @@ EPI1377780|A/Indonesia/NIHRD7393/2008.4	A/Indonesia/NIHRD7393/2008	avian_flu	EPI
 EPI1377772|A/Indonesia/NIHRD9160/2009.4	A/Indonesia/NIHRD9160/2009	avian_flu	EPI_ISL_343405	2009-01-27	Asia	Indonesia	DKI Jakarta	NA	Human	NA
 EPI1377764|A/Indonesia/NIHRD15028/2015.4	A/Indonesia/NIHRD15028/2015	avian_flu	EPI_ISL_343404	2015-03-25	Asia	Indonesia	Banten	NA	Human	NA
 EPI1377750|A/Indonesia/NIHRD15023/2015.4	A/Indonesia/NIHRD15023/2015	avian_flu	EPI_ISL_343403	2015-03-24	Asia	Indonesia	Banten	NA	Human	NA
-EPI1377742|A/Indonesia/NIHRD13269/2013.4	A/Indonesia/NIHRD13269/2013	avian_flu	EPI_ISL_343402	2013-11-11	Asia	Indonesia	Central Java	NA	Human	NA
-EPI1377734|A/Indonesia/NIHRD13233/2013.4	A/Indonesia/NIHRD13233/2013	avian_flu	EPI_ISL_343401	2013-09-27	Asia	Indonesia	West Java	NA	Human	NA
 EPI1377720|A/Indonesia/NIHRD12452/2012.4	A/Indonesia/NIHRD12452/2012	avian_flu	EPI_ISL_343400	2012-08-01	Asia	Indonesia	DI Yogya	NA	Human	NA
 EPI1377700|A/Indonesia/NIHRD12130/2012.4	A/Indonesia/NIHRD12130/2012	avian_flu	EPI_ISL_343399	2012-02-22	Asia	Indonesia	Bali	NA	Human	NA
 EPI1377692|A/Indonesia/NIHRD12078/2012.4	A/Indonesia/NIHRD12078/2012	avian_flu	EPI_ISL_343398	2012-02-12	Asia	Indonesia	Banten	NA	Human	NA
 EPI1377684|A/Indonesia/NIHRD11771/2011.4	A/Indonesia/NIHRD11771/2011	avian_flu	EPI_ISL_343397	2011-08-07	Asia	Indonesia	Bali	NA	Human	NA
-EPI1377676|A/Indonesia/NIHRD11454/2011.4	A/Indonesia/NIHRD11454/2011	avian_flu	EPI_ISL_343396	2011-04-08	Asia	Indonesia	DKI Jakarta	NA	Human	NA
 EPI1377668|A/Indonesia/NIHRD11073/2011.4	A/Indonesia/NIHRD11073/2011	avian_flu	EPI_ISL_343395	2011-02-02	Asia	Indonesia	West Java	NA	Human	NA
-EPI1377660|A/Indonesia/NIHRD11046/2011.4	A/Indonesia/NIHRD11046/2011	avian_flu	EPI_ISL_343394	2011-02-03	Asia	Indonesia	West Java	NA	Human	NA
-EPI1377652|A/Indonesia/NIHRD10728/2010.4	A/Indonesia/NIHRD10728/2010	avian_flu	EPI_ISL_343393	2010-11-21	Asia	Indonesia	West Java	NA	Human	NA
 EPI1377644|A/Indonesia/NIHRD10529/2010.4	A/Indonesia/NIHRD10529/2010	avian_flu	EPI_ISL_343392	2010-07-07	Asia	Indonesia	Banten	NA	Human	NA
-EPI1377636|A/Indonesia/NIHRD10459/2010.4	A/Indonesia/NIHRD10459/2010	avian_flu	EPI_ISL_343391	2010-06-01	Asia	Indonesia	DKI Jakarta	NA	Human	NA
-EPI1377628|A/Indonesia/NIHRD10364/2010.4	A/Indonesia/NIHRD10364/2010	avian_flu	EPI_ISL_343390	2010-04-25	Asia	Indonesia	Riau	NA	Human	NA
 EPI1377620|A/Indonesia/NIHRD9665/2009.4	A/Indonesia/NIHRD9665/2009	avian_flu	EPI_ISL_343389	2009-05-30	Asia	Indonesia	DKI Jakarta	NA	Human	NA
 EPI1377612|A/Indonesia/NIHRD9653/2009.4	A/Indonesia/NIHRD9653/2009	avian_flu	EPI_ISL_343388	2009-05-22	Asia	Indonesia	DKI Jakarta	NA	Human	NA
-EPI1377604|A/Indonesia/NIHRD9340/2009.4	A/Indonesia/NIHRD9340/2009	avian_flu	EPI_ISL_343387	2009-02-27	Asia	Indonesia	West Java	NA	Human	NA
 EPI1377596|A/Indonesia/NIHRD9158/2009.4	A/Indonesia/NIHRD9158/2009	avian_flu	EPI_ISL_343386	2009-01-22	Asia	Indonesia	West Java	NA	Human	NA
 EPI1377588|A/Indonesia/NIHRD8987/2008.4	A/Indonesia/NIHRD8987/2008	avian_flu	EPI_ISL_343385	2008-12-14	Asia	Indonesia	Banten	NA	Human	NA
-EPI1377580|A/Indonesia/NIHRD7988/2008.4	A/Indonesia/NIHRD7988/2008	avian_flu	EPI_ISL_343384	2008-04-23	Asia	Indonesia	Central Java	NA	Human	NA
 EPI1377572|A/Indonesia/NIHRD7802/2008.4	A/Indonesia/NIHRD7802/2008	avian_flu	EPI_ISL_343383	2008-03-28	Asia	Indonesia	West Java	NA	Human	NA
 EPI1377564|A/Indonesia/NIHRD7781/2008.4	A/Indonesia/NIHRD7781/2008	avian_flu	EPI_ISL_343382	2008-03-25	Asia	Indonesia	West Sumatra	NA	Human	NA
-EPI643072|A/Indonesia/NIHRD15028/2015	A/Indonesia/NIHRD15028/2015	avian_flu	EPI_ISL_195732	2015-03-25	Asia	Indonesia	Banten	NA	Human	NA
 EPI643069|A/Indonesia/NIHRD/15023	A/Indonesia/NIHRD/15023/2015	avian_flu	EPI_ISL_195731	2015-03-24	Asia	Indonesia	Banten	NA	Human	NA
-EPI642537|A/Egypt/682/2015	A/Egypt/682/2015	avian_flu	EPI_ISL_195659	2015-01-15	Africa	Egypt	NA	NA	Human	NA
 NA	A/CAM/Q0321176/2006	avian_flu	EPI_ISL_179028	2006-03-21	Asia	Cambodia	Khett Kampong Spoe	NA	Human	NA
 EPI531959|A/Indonesia/NIHRD14122/2014	A/Indonesia/NIHRD14122/2014	avian_flu	EPI_ISL_162667	2014-04-19	Asia	Indonesia	Central Java	NA	Human	NA
 NA	A/Thailand/RPNPNA/2005	avian_flu	EPI_ISL_64777	NA	Asia	Thailand	NA	NA	Human	NA
@@ -23575,7 +23021,6 @@ EPI226841|A/Thailand/NKNPHA/2005	A/Thailand/NKNPHA/2005	avian_flu	EPI_ISL_64772	
 NA	A/Thailand/NKFENA/2005	avian_flu	EPI_ISL_64771	NA	Asia	Thailand	NA	NA	Human	NA
 EPI226839|A/Thailand/NKFEHA/2005	A/Thailand/NKFEHA/2005	avian_flu	EPI_ISL_64770	NA	Asia	Thailand	NA	NA	Human	NA
 EPI226718|A/Indonesia/160H/2005	A/Indonesia/160H/2005	avian_flu	EPI_ISL_64676	2005-11-08	Asia	Indonesia	NA	NA	Human	NA
-EPI1620078|A/Thailand/NBL1/2006, EPI1620070|A/Thailand/NBL1/2006, EPI1620062|A/Thailand/NBL1/2006, EPI1620054|A/Thailand/NBL1/2006, EPI224903|A/Thailand/NBL1/2006	A/Thailand/NBL1/2006	avian_flu	EPI_ISL_64276	2006-08-10	Asia	Thailand	NA	NA	Human	NA
 EPI184849|A/Egypt/N05056/2009	A/Egypt/N05056/2009	avian_flu	EPI_ISL_31746	2009-06-06	Africa	Egypt	NA	NA	Human	NA
 EPI184847|A/Egypt/N04979/2009	A/Egypt/N04979/2009	avian_flu	EPI_ISL_31745	2009-05-31	Africa	Egypt	Sharqia	Kafr ash Shaykh	Human	NA
 EPI184845|A/Egypt/N04823/2009	A/Egypt/N04823/2009	avian_flu	EPI_ISL_31744	2009-05-25	Africa	Egypt	NA	NA	Human	NA
@@ -23638,7 +23083,6 @@ EPI284577|2008742338	A/duck/Vietnam/NCVD-001/2008	avian_flu	EPI_ISL_80742	NA	Asi
 EPI284576|2008742318	A/duck/Vietnam/NCVD-107/2007	avian_flu	EPI_ISL_80741	NA	Asia	Vietnam	Thai Binh	NA	Avian	NA
 EPI284575|2008742316	A/duck/Vietnam/NCVD-105/2007	avian_flu	EPI_ISL_80740	NA	Asia	Vietnam	Thai Binh	NA	Avian	NA
 EPI284574|2008742313	A/duck/Vietnam/NCVD-102/2007	avian_flu	EPI_ISL_80739	NA	Asia	Vietnam	Thai Binh	NA	Avian	NA
-EPI284573|2008742311	A/duck/Vietnam/NCVD-100/2007	avian_flu	EPI_ISL_80738	NA	Asia	Vietnam	Thai Binh	NA	Avian	NA
 EPI284572|2008742305	A/duck/Vietnam/NCVD-94/2007	avian_flu	EPI_ISL_80737	NA	Asia	Vietnam	Thai Binh	NA	Avian	NA
 EPI284571|2008742327	A/duck/Vietnam/NCVD-116/2007	avian_flu	EPI_ISL_80736	NA	Asia	Vietnam	Son La	NA	Avian	NA
 EPI284570|2008742324	A/duck/Vietnam/NCVD-113/2007	avian_flu	EPI_ISL_80735	NA	Asia	Vietnam	Son La	NA	Avian	NA
@@ -23732,7 +23176,6 @@ EPI2611300|A/chicken/China/YZU-03/2016_HA	A/chicken/China/YZU-03/2016	avian_flu	
 NA	A/chicken/China/YZU-02/2016	avian_flu	EPI_ISL_17956168	2016-03-03	Asia	China	NA	NA	Chicken	NA
 EPI2611298|A/chicken/China/YZU-01/2016_HA	A/chicken/China/YZU-01/2016	avian_flu	EPI_ISL_17956167	2016-03-03	Asia	China	NA	NA	Chicken	NA
 EPI2506481|A/chicken/Nigeria/VRD-21-361_21VIR7423-34/2021_HA	A/chicken/Nigeria/VRD-21-361_21VIR7423-34/2021	avian_flu	EPI_ISL_17414658	2021-07-09	Africa	Nigeria	Lagos State	NA	Chicken	NA
-EPI2193007|A/chicken/Ghana/AVL-763_21VIR7050-39/2021	A/chicken/Ghana/AVL-763_21VIR7050-39/2021	avian_flu	EPI_ISL_15350905	2021-06-08	Africa	Ghana	NA	NA	Chicken	NA
 EPI2141549|A/broiler/Italy/21VIR11802-1/2021_HA	A/broiler/Italy/21VIR11802-1/2021	avian_flu	EPI_ISL_14761188	2021-12-27	Europe	Italy	NA	NA	Chicken	NA
 EPI2141532|A/broiler/Italy/21VIR11800/2021_HA	A/broiler/Italy/21VIR11800/2021	avian_flu	EPI_ISL_14761165	2021-12-27	Europe	Italy	NA	NA	Chicken	NA
 EPI2141435|A/broiler/Italy/21VIR11583-1/2021_HA	A/broiler/Italy/21VIR11583-1/2021	avian_flu	EPI_ISL_14761041	2021-12-22	Europe	Italy	NA	NA	Chicken	NA
@@ -23772,13 +23215,11 @@ EPI644391|A/chicken/Bhutan/01TI06/2013	A/chicken/Bhutan/01TI06/2013	avian_flu	EP
 EPI644388|A/chicken/Bhutan/01TR340/2013	A/chicken/Bhutan/01TR340/2013	avian_flu	EPI_ISL_195951	2013-01-29	Asia	Bhutan	NA	NA	Chicken	NA
 EPI644385|A/chicken/Bhutan/01TR338/2013	A/chicken/Bhutan/01TR338/2013	avian_flu	EPI_ISL_195950	2013-01-29	Asia	Bhutan	NA	NA	Chicken	NA
 EPI644382|A/chicken/Bhutan/02CL505/2013	A/chicken/Bhutan/02CL505/2013	avian_flu	EPI_ISL_195949	2013-01-29	Asia	Bhutan	NA	NA	Chicken	NA
-NA	A/chicken/India/09CA02/2011	avian_flu	EPI_ISL_195947	2011-09-02	Asia	India	NA	NA	Chicken	NA
 NA	A/chicken/India/09CA01/2011	avian_flu	EPI_ISL_195946	2011-09-02	Asia	India	NA	NA	Chicken	NA
 EPI643194|A/chicken/Ghana/FJ152511/2015	A/chicken/Ghana/FJ152511/2015	avian_flu	EPI_ISL_195791	NA	Africa	Ghana	NA	NA	Chicken	NA
 EPI642472|A/chicken/India/03CA02/2012	A/chicken/India/03CA02/2012	avian_flu	EPI_ISL_195644	2012-03-05	Asia	India	NA	NA	Chicken	NA
 EPI644490|A/chicken/Bhutan/01TR12/2012	A/chicken/Bhutan/01TR12/2012	avian_flu	EPI_ISL_195642	2012-01-02	Asia	Bhutan	NA	NA	Chicken	NA
 EPI644483|A/chicken/Bhutan/01CL140/2012	A/chicken/Bhutan/01CL140/2012	avian_flu	EPI_ISL_195640	2012-01-02	Asia	Bhutan	NA	NA	Chicken	NA
-NA	A/chicken/Nepal/08TI87/2013	avian_flu	EPI_ISL_195638	2013-08-25	Asia	Nepal	NA	NA	Chicken	NA
 NA	A/chicken/Nepal/08TI86/2013	avian_flu	EPI_ISL_195637	2013-08-25	Asia	Nepal	NA	NA	Chicken	NA
 EPI642475|A/chicken/India/03CA03/2012	A/chicken/India/03CA03/2012	avian_flu	EPI_ISL_195600	2012-03-05	Asia	India	NA	NA	Chicken	NA
 EPI641671|A/chicken/Niger/15VIR2060-6/2015	A/chicken/Niger/15VIR2060-6/2015	avian_flu	EPI_ISL_195416	2015-04-04	Africa	Niger	NA	NA	Chicken	NA
@@ -23794,10 +23235,8 @@ EPI590116|A/chicken/Tonghai/802/2014	A/chicken/Tonghai/802/2014	avian_flu	EPI_IS
 EPI590115|A/chicken/Tonghai/5/2014	A/chicken/Tonghai/5/2014	avian_flu	EPI_ISL_179401	2014-01-12	Asia	China	NA	NA	Chicken	NA
 EPI590114|A/chicken/Tonghai/3/2014	A/chicken/Tonghai/3/2014	avian_flu	EPI_ISL_179400	2014-01-10	Asia	China	NA	NA	Chicken	NA
 EPI590113|A/chicken/DaLi/502/2014	A/chicken/DaLi/502/2014	avian_flu	EPI_ISL_179399	2014-01-10	Asia	China	NA	NA	Chicken	NA
-EPI590112|A/chicken/DaLi/302/2014	A/chicken/DaLi/302/2014	avian_flu	EPI_ISL_179398	2014-01-01	Asia	China	NA	NA	Chicken	NA
 EPI590111|A/chicken/AnNing/6/2014	A/chicken/AnNing/6/2014	avian_flu	EPI_ISL_179397	2014-01-10	Asia	China	NA	NA	Chicken	NA
 EPI590110|A/chicken/AnNing/4/2014	A/chicken/AnNing/4/2014	avian_flu	EPI_ISL_179396	2014-01-10	Asia	China	NA	NA	Chicken	NA
-EPI590109|A/chicken/AnNing/1/2014	A/chicken/AnNing/1/2014	avian_flu	EPI_ISL_179395	2014-01-01	Asia	China	NA	NA	Chicken	NA
 EPI532498|A/chicken/Guizhou/05/2013	A/chicken/Guizhou/05/2013	avian_flu	EPI_ISL_162930	2013-10-23	Asia	China	NA	NA	Chicken	NA
 EPI532497|A/chicken/Guizhou/04/2013	A/chicken/Guizhou/04/2013	avian_flu	EPI_ISL_162929	2013-10-23	Asia	China	NA	NA	Chicken	NA
 EPI532496|A/chicken/Guizhou/03/2013	A/chicken/Guizhou/03/2013	avian_flu	EPI_ISL_162928	2013-10-23	Asia	China	NA	NA	Chicken	NA
@@ -23849,10 +23288,6 @@ EPI338788|A/chicken/Bangladesh/BL-543/2011	A/chicken/Bangladesh/BL-543/2011	avia
 EPI338787|A/chicken/Bangladesh/BL-558/2011	A/chicken/Bangladesh/BL-558/2011	avian_flu	EPI_ISL_97233	2011-03-02	Asia	Bangladesh	NA	NA	Chicken	NA
 EPI338730|A/chicken/Egypt/S2938A/2011	A/chicken/Egypt/S2938A/2011	avian_flu	EPI_ISL_97211	2011-02-28	Africa	Egypt	NA	NA	Chicken	NA
 EPI338729|A/chicken/Egypt/S3093A/2011	A/chicken/Egypt/S3093A/2011	avian_flu	EPI_ISL_97210	2011-03-30	Africa	Egypt	NA	NA	Chicken	NA
-EPI338617|A/chicken/Egypt/Q1995D/2010	A/chicken/Egypt/Q1995D/2010	avian_flu	EPI_ISL_97153	2010-07-23	Africa	Egypt	NA	NA	Chicken	NA
-EPI338614|A/chicken/Egypt/M2773A/2011	A/chicken/Egypt/M2773A/2011	avian_flu	EPI_ISL_97150	2011-01-19	Africa	Egypt	NA	NA	Chicken	NA
-EPI338609|A/chicken/Egypt/S3280B/2011	A/chicken/Egypt/S3280B/2011	avian_flu	EPI_ISL_97145	2011-05-12	Africa	Egypt	NA	NA	Chicken	NA
-EPI338608|A/chicken/Egypt/S3280D/2011	A/chicken/Egypt/S3280D/2011	avian_flu	EPI_ISL_97144	2011-05-12	Africa	Egypt	NA	NA	Chicken	NA
 EPI338293|A/chicken/Thailand/KU14/2004	A/chicken/Thailand/KU14/2004	avian_flu	EPI_ISL_97041	NA	Asia	Thailand	NA	NA	Chicken	NA
 EPI286399|A/chicken/Thai Binh/07-89/2007	A/chicken/Thai Binh/07-89/2007	avian_flu	EPI_ISL_80952	NA	Asia	Vietnam	NA	NA	Chicken	NA
 EPI286393|A/chicken/Ha Nam/07-83/2007	A/chicken/Ha Nam/07-83/2007	avian_flu	EPI_ISL_80946	NA	Asia	Vietnam	NA	NA	Chicken	NA
@@ -23889,10 +23324,7 @@ EPI226957|A/chicken/Deli Serdang/BPPVI/2005	A/chicken/Deli Serdang/BPPVI/2005	av
 EPI226949|A/chicken/Dairi/BPPVI/2005	A/chicken/Dairi/BPPVI/2005	avian_flu	EPI_ISL_64823	NA	Asia	Indonesia	NA	NA	Chicken	NA
 EPI226920|A/Chicken/Bantul/BBVet-I/2005	A/Chicken/Bantul/BBVet-I/2005	avian_flu	EPI_ISL_64820	NA	Asia	Indonesia	NA	NA	Chicken	NA
 NA	A/Indonesia/CDC60/2005	avian_flu	EPI_ISL_64677	NA	Asia	Indonesia	NA	NA	Chicken	NA
-EPI226657|A/Chicken/Siak/BPPV-II/2005	A/Chicken/Siak/BPPV-II/2005	avian_flu	EPI_ISL_64631	NA	Asia	Indonesia	NA	NA	Chicken	NA
-EPI226656|A/Chicken/Sembawa/BPPV-III/2005	A/Chicken/Sembawa/BPPV-III/2005	avian_flu	EPI_ISL_64630	NA	Asia	Indonesia	NA	NA	Chicken	NA
 EPI226655|A/Chicken/Salam/BBPV-II/2005	A/Chicken/Salam/BBPV-II/2005	avian_flu	EPI_ISL_64629	NA	Asia	Indonesia	NA	NA	Chicken	NA
-EPI226654|A/Chicken/Rokan Hilli/BPPV-II/2005	A/Chicken/Rokan Hilli/BPPV-II/2005	avian_flu	EPI_ISL_64628	NA	Asia	Indonesia	NA	NA	Chicken	NA
 EPI226653|A/Chicken/Palembang/BPPV-III/2005	A/Chicken/Palembang/BPPV-III/2005	avian_flu	EPI_ISL_64627	NA	Asia	Indonesia	NA	NA	Chicken	NA
 EPI226652|A/Chicken/Pakun Baru/BPPV-II/2005	A/Chicken/Pakun Baru/BPPV-II/2005	avian_flu	EPI_ISL_64626	NA	Asia	Indonesia	NA	NA	Chicken	NA
 EPI226651|A/Chicken/Murao Jambi/BBPV-II/2005	A/Chicken/Murao Jambi/BBPV-II/2005	avian_flu	EPI_ISL_64625	NA	Asia	Indonesia	NA	NA	Chicken	NA
@@ -23950,7 +23382,6 @@ EPI136757|A/chicken/Egypt/07202-NLQP/2007	A/chicken/Egypt/07202-NLQP/2007	avian_
 EPI136755|A/chicken/Egypt/07201-NLQP/2007	A/chicken/Egypt/07201-NLQP/2007	avian_flu	EPI_ISL_15705	2007-12-18	Africa	Egypt	NA	NA	Chicken	NA
 EPI136753|A/chicken/Egypt/07181-NLQP/2007	A/chicken/Egypt/07181-NLQP/2007	avian_flu	EPI_ISL_15704	2007-06-19	Africa	Egypt	Faiyum	NA	Chicken	NA
 EPI136749|A/chicken/Egypt/06612-NLQP/2006	A/chicken/Egypt/06612-NLQP/2006	avian_flu	EPI_ISL_15702	2006-03-24	Africa	Egypt	Sohag	NA	Chicken	NA
-EPI136747|A/chicken/Egypt/06553-NLQP/2006	A/chicken/Egypt/06553-NLQP/2006	avian_flu	EPI_ISL_15701	2006-03-21	Africa	Egypt	NA	NA	Chicken	NA
 EPI136627|A/chicken/Czech_Republic/11242-38/07	A/chicken/Czech Republic/11242-38/07	avian_flu	EPI_ISL_15691	2007-07-11	Europe	Czech Republic	Pardubicky kraj	Chocen	Chicken	NA
 EPI136432|A/chicken/Yunnan/207/2004	A/chicken/Yunnan/207/2004	avian_flu	EPI_ISL_15678	NA	Asia	China	Yunnan Province	NA	Chicken	NA
 EPI136413|A/chicken/Yunnan/6957/2003	A/chicken/Yunnan/6957/2003	avian_flu	EPI_ISL_15677	NA	Asia	China	Yunnan Province	NA	Chicken	NA
@@ -23985,7 +23416,6 @@ EPI132625|A/chicken/Kuwait/KISR6/2007	A/chicken/Kuwait/KISR6/2007	avian_flu	EPI_
 EPI132606|A/chicken/Kuwait/KISR5/2007	A/chicken/Kuwait/KISR5/2007	avian_flu	EPI_ISL_15278	NA	Asia	Kuwait	NA	NA	Chicken	NA
 EPI132587|A/chicken/Kuwait/KISR3/2007	A/chicken/Kuwait/KISR3/2007	avian_flu	EPI_ISL_15277	NA	Asia	Kuwait	NA	NA	Chicken	NA
 EPI132568|A/chicken/Kuwait/KISR2/2007	A/chicken/Kuwait/KISR2/2007	avian_flu	EPI_ISL_15276	NA	Asia	Kuwait	NA	NA	Chicken	NA
-EPI132115|A/chicken/Benin/6693-16/2007	A/chicken/Benin/6693-16/2007	avian_flu	EPI_ISL_15160	NA	Africa	Benin	NA	NA	Chicken	NA
 NA	A/chicken/Vietnam/KG88/2008	avian_flu	EPI_ISL_129964	2008-03-21	Asia	Vietnam	NA	NA	Gallus gallus	NA
 NA	A/chicken/Vietnam/VL/2005	avian_flu	EPI_ISL_129963	2005-11-15	Asia	Vietnam	NA	NA	Gallus gallus	NA
 EPI2528518|A/duck/Egypt/RA19853OP/2021	A/duck/Egypt/RA19853OP/2021	avian_flu	EPI_ISL_17529372	2021-12-15	Africa	Egypt	NA	NA	Duck	NA
@@ -24004,7 +23434,6 @@ EPI1153425|A/duck/France/150290/2015	A/duck/France/150290/2015	avian_flu	EPI_ISL
 EPI1153417|A/duck/France/160678/2016	A/duck/France/160678/2016	avian_flu	EPI_ISL_293980	2016-07-15	Europe	France	NA	NA	Duck	Domestic
 NA	A/duck/Bhutan/01TR03/2013	avian_flu	EPI_ISL_195954	2013-01-29	Asia	Bhutan	NA	NA	Duck	NA
 EPI644394|A/duck/Bhutan/01CL03/2013	A/duck/Bhutan/01CL03/2013	avian_flu	EPI_ISL_195953	2013-01-29	Asia	Bhutan	NA	NA	Duck	NA
-EPI644398|A/duck/Bhutan/01TR03/2013	A/duck/Bhutan/01TR03/2013	avian_flu	EPI_ISL_195634	2013-01-29	Asia	Bhutan	NA	NA	Duck	NA
 EPI590491|A/duck/Egypt/BSU-NLQP-BS-4/2014	A/duck/Egypt/BSU-NLQP-BS-4/2014	avian_flu	EPI_ISL_179565	2014-03-21	Africa	Egypt	NA	NA	Duck	NA
 EPI590490|A/duck/Egypt/BSU-NLQP-BS-3/2014	A/duck/Egypt/BSU-NLQP-BS-3/2014	avian_flu	EPI_ISL_179564	2014-03-05	Africa	Egypt	NA	NA	Duck	NA
 EPI590485|A/duck/Egypt/BSU-NLQP-MN-1/2009	A/duck/Egypt/BSU-NLQP-MN-1/2009	avian_flu	EPI_ISL_179559	2009-02-20	Africa	Egypt	NA	NA	Duck	NA
@@ -24015,7 +23444,6 @@ NA	A/duck/CAM/202W6M1/2013	avian_flu	EPI_ISL_179042	2013-02-04	Asia	Cambodia	Khe
 EPI398581|A/duck/Egypt/Q4596D/2012	A/duck/Egypt/Q4596D/2012	avian_flu	EPI_ISL_129889	2012-01-19	Africa	Egypt	NA	NA	Duck	NA
 EPI398575|A/duck/Egypt/Q4596C/2012	A/duck/Egypt/Q4596C/2012	avian_flu	EPI_ISL_129885	2012-01-19	Africa	Egypt	NA	NA	Duck	NA
 EPI398230|A/duck/El Fayoum/CAI1/2010	A/duck/El Fayoum/CAI1/2010	avian_flu	EPI_ISL_129835	2010-03-01	Africa	Egypt	NA	NA	Duck	NA
-EPI2579846|A/duck/Qalubia/CAI11/2010	A/duck/Qalubia/CAI11/2010	avian_flu	EPI_ISL_129818	2010-03-01	Africa	Egypt	NA	NA	Duck	NA
 EPI398164|A/duck/El Fayoum/CAI9/2010	A/duck/El Fayoum/CAI9/2010	avian_flu	EPI_ISL_129817	2010-03-01	Africa	Egypt	NA	NA	Duck	NA
 EPI338786|A/duck/Bangladesh/BoBL-3/2011	A/duck/Bangladesh/BoBL-3/2011	avian_flu	EPI_ISL_97232	2011-01-24	Asia	Bangladesh	NA	NA	Duck	NA
 EPI338733|A/duck/Egypt/M2583B/2010	A/duck/Egypt/M2583B/2010	avian_flu	EPI_ISL_97214	2010-12-22	Africa	Egypt	NA	NA	Duck	NA
@@ -24023,7 +23451,6 @@ EPI338732|A/duck/Egypt/M2583C/2010	A/duck/Egypt/M2583C/2010	avian_flu	EPI_ISL_97
 EPI338618|A/duck/Egypt/M2583A/2010	A/duck/Egypt/M2583A/2010	avian_flu	EPI_ISL_97154	2010-12-22	Africa	Egypt	NA	NA	Duck	NA
 EPI338616|A/duck/Egypt/M2583D/2010	A/duck/Egypt/M2583D/2010	avian_flu	EPI_ISL_97152	2010-12-22	Africa	Egypt	NA	NA	Duck	NA
 EPI338615|A/duck/Egypt/Q2645C/2010	A/duck/Egypt/Q2645C/2010	avian_flu	EPI_ISL_97151	2010-12-26	Africa	Egypt	NA	NA	Duck	NA
-EPI338610|A/duck/Egypt/M3075B/2011	A/duck/Egypt/M3075B/2011	avian_flu	EPI_ISL_97146	2011-03-22	Africa	Egypt	NA	NA	Duck	NA
 EPI286621|A/muscovy duck/Thai Binh/07-90/2007	A/muscovy duck/Thai Binh/07-90/2007	avian_flu	EPI_ISL_81022	NA	Asia	Vietnam	NA	NA	Duck	NA
 EPI286620|A/muscovy duck/Nam Dinh/07-87/2007	A/muscovy duck/Nam Dinh/07-87/2007	avian_flu	EPI_ISL_81021	NA	Asia	Vietnam	NA	NA	Duck	NA
 EPI286619|A/muscovy duck/Son La/07-85/2007	A/muscovy duck/Son La/07-85/2007	avian_flu	EPI_ISL_81020	NA	Asia	Vietnam	NA	NA	Duck	NA
@@ -24054,12 +23481,10 @@ NA	A/Duck/Pali/BBVW/2005	avian_flu	EPI_ISL_64641	NA	Asia	Indonesia	NA	NA	Duck	NA
 EPI226618|A/wild duck/Sweden/06	A/wild duck/Sweden/06	avian_flu	EPI_ISL_64594	NA	Europe	Sweden	NA	NA	Duck	Wild
 NA	A/duck/Viet Nam/DT-9/2006	avian_flu	EPI_ISL_64365	NA	Asia	Vietnam	NA	NA	Duck	NA
 EPI225105|A/duck/Omsk/1822/2006	A/duck/Omsk/1822/2006	avian_flu	EPI_ISL_64356	NA	Europe	Russian Federation	NA	NA	Duck	NA
-EPI225089|A/duck/Hungary/11804/2006	A/duck/Hungary/11804/2006	avian_flu	EPI_ISL_64353	NA	Europe	Hungary	NA	NA	Duck	NA
 EPI225081|A/duck/Hai Phong /208/2006	A/duck/Hai Phong /208/2006	avian_flu	EPI_ISL_64352	NA	Asia	Vietnam	NA	NA	Duck	NA
 EPI225079|A/duck/Gaza/834/2006	A/duck/Gaza/834/2006	avian_flu	EPI_ISL_64351	NA	Asia	Palestinian Territory	Gaza Strip	NA	Duck	NA
 EPI225077|A/duck/Gaza/760/2006	A/duck/Gaza/760/2006	avian_flu	EPI_ISL_64350	NA	Asia	Palestinian Territory	Gaza Strip	NA	Duck	NA
 EPI225076|A/duck/Egypt/2253-3/2006	A/duck/Egypt/2253-3/2006	avian_flu	EPI_ISL_64349	NA	Africa	Egypt	NA	NA	Duck	NA
-EPI225068|A/duck/Egypt/2253-3/2006	A/duck/Egypt/2253-3/2006	avian_flu	EPI_ISL_64348	NA	Africa	Egypt	NA	NA	Duck	NA
 NA	A/duck/Doualare/Cameroon/3255/2006	avian_flu	EPI_ISL_64347	NA	Africa	Cameroon	NA	NA	Duck	NA
 NA	A/teal/Viet Nam/MBP5/2006	avian_flu	EPI_ISL_31528	NA	Asia	Vietnam	NA	NA	Duck	NA
 EPI136781|A/duck/Egypt/07322S-NLQP/2007	A/duck/Egypt/07322S-NLQP/2007	avian_flu	EPI_ISL_15718	2007-03-20	Africa	Egypt	NA	NA	Duck	NA
@@ -24086,7 +23511,6 @@ EPI135938|A/duck/Hunan/782/2003	A/duck/Hunan/782/2003	avian_flu	EPI_ISL_15652	NA
 EPI135919|A/duck/Hunan/378/2003	A/duck/Hunan/378/2003	avian_flu	EPI_ISL_15651	NA	Asia	China	Hunan Province	NA	Duck	NA
 EPI135900|A/duck/Hunan/300/2003	A/duck/Hunan/300/2003	avian_flu	EPI_ISL_15650	NA	Asia	China	Hunan Province	NA	Duck	NA
 EPI135881|A/duck/Hunan/1340/2002	A/duck/Hunan/1340/2002	avian_flu	EPI_ISL_15649	NA	Asia	China	Hunan Province	NA	Duck	NA
-EPI135862|A/duck/Hunan/795/2002	A/duck/Hunan/795/2002	avian_flu	EPI_ISL_15648	NA	Asia	China	Hunan Province	NA	Duck	NA
 EPI135482|A/duck/Shantou/700/2002	A/duck/Shantou/700/2002	avian_flu	EPI_ISL_15628	NA	Asia	China	NA	NA	Duck	NA
 EPI135349|A/duck/Shantou/5526/2001	A/duck/Shantou/5526/2001	avian_flu	EPI_ISL_15621	NA	Asia	China	NA	NA	Duck	NA
 EPI135292|A/duck/Shantou/4912/2001	A/duck/Shantou/4912/2001	avian_flu	EPI_ISL_15618	NA	Asia	China	NA	NA	Duck	NA
@@ -24238,15 +23662,12 @@ EPI287348|ucoq50_HA_Segment4_00001	A/MDCK/Germany/[A/cygnus cygnus/Germany/R65/2
 EPI1859676|A/Hong Kong/213/2003  NIBRG-12  (08/154)	A/Hong Kong/213/2003  NIBRG-12  (08/154)	avian_flu	EPI_ISL_2080353	2003-01-01	Asia	Hong Kong (SAR)	NA	NA	Laboratory derived	NA
 EPI2017310|06S543	NIBRG-14(A/Vietnam/1194/2004)	avian_flu	EPI_ISL_11976295	NA	Europe	United Kingdom	NA	NA	Laboratory derived	NA
 NA	A/Dk/Indonesia/MS/2004	avian_flu	EPI_ISL_65201	NA	Asia	Indonesia	NA	NA	Unknown	NA
-EPI141279|A/Jiangsu/1/2007	A/Jiangsu/1/2007	avian_flu	EPI_ISL_16357	NA	Asia	China	Jiangsu Provice	Jiangsu Sheng	Human	NA
 NA	A/Viet Nam/HN/2004	avian_flu	EPI_ISL_65207	NA	Asia	Vietnam	NA	NA	Human	NA
 EPI228449|A/Thailand/Kamphaengphet-Nontaburi/04	A/Thailand/Kamphaengphet-Nontaburi/04	avian_flu	EPI_ISL_65209	NA	Asia	Thailand	NA	NA	Human	NA
 NA	A/Vietnam/CL02/2005	avian_flu	EPI_ISL_65316	NA	Asia	Vietnam	NA	NA	Human	NA
 EPI1377796|A/Indonesia/NIHRD10612/2010.4	A/Indonesia/NIHRD10612/2010	avian_flu	EPI_ISL_343408	2010-08-25	Asia	Indonesia	DKI Jakarta	NA	Human	NA
-EPI1377804|A/Indonesia/NIHRD10623/2010.4	A/Indonesia/NIHRD10623/2010	avian_flu	EPI_ISL_343409	2010-09-16	Asia	Indonesia	West Java	NA	Human	NA
 EPI1377812|A/Indonesia/NIHRD11198/2011.4	A/Indonesia/NIHRD11198/2011	avian_flu	EPI_ISL_343410	2011-03-04	Asia	Indonesia	West Java	NA	Human	NA
 EPI1377833|A/Indonesia/NIHRD9152/2009.4	A/Indonesia/NIHRD9152/2009	avian_flu	EPI_ISL_343411	2009-01-23	Asia	Indonesia	East Java	NA	Human	NA
-EPI141271|A/Jiangsu/2/2007	A/Jiangsu/2/2007	avian_flu	EPI_ISL_16356	NA	Asia	China	Jiangsu Provice	Jiangsu Sheng	Human	NA
 EPI228832|A/Vietnam/CL02/2004	A/Vietnam/CL02/2004	avian_flu	EPI_ISL_65314	NA	Asia	Vietnam	NA	NA	Human	NA
 NA	A/eka/Thailand/EkA1NRC/2004	avian_flu	EPI_ISL_65180	NA	Asia	Thailand	NA	NA	Avian	NA
 NA	A/crow/Bangkok/Thailand/2004	avian_flu	EPI_ISL_65203	NA	Asia	Thailand	NA	NA	Avian	NA
@@ -24345,32 +23766,21 @@ EPI340121|A/chicken/Egypt/1146SF/2011	A/chicken/Egypt/1146SF/2011	avian_flu	EPI_
 EPI340122|A/chicken/Egypt/1128/2011	A/chicken/Egypt/1128/2011	avian_flu	EPI_ISL_98160	2011-01-21	Africa	Egypt	NA	NA	Chicken	NA
 EPI340124|A/chicken/Egypt/114AF/2011	A/chicken/Egypt/114AF/2011	avian_flu	EPI_ISL_98162	2011-01-20	Africa	Egypt	NA	NA	Chicken	NA
 EPI400176|A/chicken/VRLCU140/Egypt/2012	A/chicken/VRLCU140/Egypt/2012	avian_flu	EPI_ISL_130434	NA	Africa	Egypt	NA	NA	Chicken	NA
-NA	A/chicken/Nepal/08TI78/2013	avian_flu	EPI_ISL_195957	2013-08-25	Asia	Nepal	NA	NA	Chicken	NA
-NA	A/chicken/Nepal/08TI86/2013	avian_flu	EPI_ISL_195958	2013-08-25	Asia	Nepal	NA	NA	Chicken	NA
-EPI2580123|A/chicken/Nepal/08TI87/2013	A/chicken/Nepal/08TI87/2013	avian_flu	EPI_ISL_195959	2013-08-25	Asia	Nepal	NA	NA	Chicken	NA
 NA	A/chicken/Nepal/08TI124/2013	avian_flu	EPI_ISL_195960	2013-08-25	Asia	Nepal	NA	NA	Chicken	NA
-NA	A/chicken/Nepal/08TI63/2013	avian_flu	EPI_ISL_195961	2013-08-25	Asia	Nepal	NA	NA	Chicken	NA
-NA	A/chicken/Nepal/08TI76/2013	avian_flu	EPI_ISL_195962	2013-08-25	Asia	Nepal	NA	NA	Chicken	NA
-NA	A/chicken/Nepal/08TI82/2013	avian_flu	EPI_ISL_195963	2013-08-25	Asia	Nepal	NA	NA	Chicken	NA
-NA	A/chicken/Nepal/08TI96/2013	avian_flu	EPI_ISL_195964	2013-08-25	Asia	Nepal	NA	NA	Chicken	NA
 NA	A/chicken/India/01CL1196/2012	avian_flu	EPI_ISL_195966	2012-01-11	Asia	India	NA	NA	Chicken	NA
-NA	A/chicken/India/09CA09/2011	avian_flu	EPI_ISL_195971	2011-09-15	Asia	India	NA	NA	Chicken	NA
 NA	A/chicken/India/09CA10/2011	avian_flu	EPI_ISL_195972	2011-09-15	Asia	India	NA	NA	Chicken	NA
 EPI644500|A/chicken/Bhutan/01CL2144/2012	A/chicken/Bhutan/01CL2144/2012	avian_flu	EPI_ISL_195978	2012-01-18	Asia	Bhutan	NA	NA	Chicken	NA
 EPI644502|A/chicken/Bhutan/01TI16/2012	A/chicken/Bhutan/01TI16/2012	avian_flu	EPI_ISL_195979	2012-01-18	Asia	Bhutan	NA	NA	Chicken	NA
 NA	A/chicken/Bhutan/01TI17/2012	avian_flu	EPI_ISL_195980	2012-01-18	Asia	Bhutan	NA	NA	Chicken	NA
 EPI806335|A/chicken/Niger/15VIR2060-12/2015	A/chicken/Niger/15VIR2060-12/2015	avian_flu	EPI_ISL_229171	2015-04-02	Africa	Niger	NA	NA	Chicken	NA
-NA	A/chicken/Niger/15VIR2060-6/2015	avian_flu	EPI_ISL_229175	2015-04-02	Africa	Niger	NA	NA	Chicken	NA
 EPI806375|A/chicken/Niger/15VIR2060-8/2015	A/chicken/Niger/15VIR2060-8/2015	avian_flu	EPI_ISL_229177	2015-04-02	Africa	Niger	NA	NA	Chicken	NA
 EPI806383|A/chicken/Ghana/15VIR2588-10/2015	A/chicken/Ghana/15VIR2588-10/2015	avian_flu	EPI_ISL_229178	2015-05-08	Africa	Ghana	NA	NA	Chicken	NA
 EPI806399|A/chicken/Ghana/15VIR2588-4/2015	A/chicken/Ghana/15VIR2588-4/2015	avian_flu	EPI_ISL_229180	NA	Africa	Ghana	NA	NA	Chicken	NA
 NA	A/chicken/Ghana/15VIR5480-10/2015	avian_flu	EPI_ISL_229182	2015-08-07	Africa	Ghana	NA	NA	Chicken	NA
 EPI806419|A/chicken/Ghana/15VIR2588-8/2015	A/chicken/Ghana/15VIR2588-8/2015	avian_flu	EPI_ISL_229183	2015-05-08	Africa	Ghana	NA	NA	Chicken	NA
 EPI806420|A/chicken/Ghana/15VIR5480-12/2015	A/chicken/Ghana/15VIR5480-12/2015	avian_flu	EPI_ISL_229184	2015-07-27	Africa	Ghana	NA	NA	Chicken	NA
-EPI806436|A/chicken/Ghana/15VIR5480-10/2015	A/chicken/Ghana/15VIR5480-10/2015	avian_flu	EPI_ISL_229185	2015-08-07	Africa	Ghana	NA	NA	Chicken	NA
 NA	A/chicken/Ghana/15VIR5480-27/2015	avian_flu	EPI_ISL_229189	2015-08-07	Africa	Ghana	NA	NA	Chicken	NA
 EPI806466|A/chicken/Ghana/15VIR5480-26/2015	A/chicken/Ghana/15VIR5480-26/2015	avian_flu	EPI_ISL_229191	2015-08-07	Africa	Ghana	NA	NA	Chicken	NA
-EPI806481|A/chicken/Ghana/15VIR5480-27/2015	A/chicken/Ghana/15VIR5480-27/2015	avian_flu	EPI_ISL_229192	2015-08-07	Africa	Ghana	NA	NA	Chicken	NA
 EPI806511|A/chicken/Burkina Faso/15VIR1774-33/2015	A/chicken/Burkina Faso/15VIR1774-33/2015	avian_flu	EPI_ISL_229197	2015-03-23	Africa	Burkina Faso	NA	NA	Chicken	NA
 EPI806526|A/chicken/Burkina Faso/15VIR1774-36/2015	A/chicken/Burkina Faso/15VIR1774-36/2015	avian_flu	EPI_ISL_229198	2015-03-23	Africa	Burkina Faso	NA	NA	Chicken	NA
 EPI806543|A/chicken/Burkina Faso/15VIR1774-38/2015	A/chicken/Burkina Faso/15VIR1774-38/2015	avian_flu	EPI_ISL_229201	2015-03-12	Africa	Burkina Faso	NA	NA	Chicken	NA
@@ -24472,10 +23882,7 @@ EPI287624|A/chicken/West Bengal/142121/2008	A/chicken/West Bengal/142121/2008	av
 EPI287631|A/chicken/West Bengal/148713/2009	A/chicken/West Bengal/148713/2009	avian_flu	EPI_ISL_81536	NA	Asia	India	NA	NA	Chicken	NA
 EPI287684|A/chicken/West Bengal/239020/2010	A/chicken/West Bengal/239020/2010	avian_flu	EPI_ISL_81582	2010-01-12	Asia	India	NA	NA	Chicken	NA
 EPI471860|A/chicken/India/03CL488/2011	A/chicken/India/03CL488/2011	avian_flu	EPI_ISL_146879	2011-03-05	Asia	India	NA	NA	Chicken	NA
-EPI472243|A/chicken/India/09CA01/2011	A/chicken/India/09CA01/2011	avian_flu	EPI_ISL_147166	NA	Asia	India	NA	NA	Chicken	NA
-EPI472245|A/chicken/India/09CA10/2011	A/chicken/India/09CA10/2011	avian_flu	EPI_ISL_147167	NA	Asia	India	NA	NA	Chicken	NA
 EPI644407|A/chicken/India/12CL2168/2013	A/chicken/India/12CL2168/2013	avian_flu	EPI_ISL_195956	2013-12-30	Asia	India	NA	NA	Chicken	NA
-EPI644438|A/chicken/India/01CL1196/2012	A/chicken/India/01CL1196/2012	avian_flu	EPI_ISL_195965	2012-01-11	Asia	India	NA	NA	Chicken	NA
 EPI644496|A/chicken/Bhutan/01CL141/2012	A/chicken/Bhutan/01CL141/2012	avian_flu	EPI_ISL_195976	2012-01-02	Asia	Bhutan	NA	NA	Chicken	NA
 EPI644498|A/chicken/Bhutan/01CL2143/2012	A/chicken/Bhutan/01CL2143/2012	avian_flu	EPI_ISL_195977	2012-01-18	Asia	Bhutan	NA	NA	Chicken	NA
 EPI2141576|A/chicken/Italy/21VIR11774-2/2021_HA	A/chicken/Italy/21VIR11774-2/2021	avian_flu	EPI_ISL_14761220	2021-12-28	Europe	Italy	NA	NA	Chicken	NA
@@ -24567,7 +23974,6 @@ EPI228626|A/chicken/Chonburi/Thailand/CU-73/04	A/chicken/Chonburi/Thailand/CU-73
 EPI228628|A/chicken/Prachinburi/Thailand/CU-104/04	A/chicken/Prachinburi/Thailand/CU-104/04	avian_flu	EPI_ISL_65297	NA	Asia	Thailand	NA	NA	Chicken	NA
 EPI533368|A/chicken/Riau/071/2009	A/chicken/Riau/071/2009	avian_flu	EPI_ISL_163366	NA	Asia	Indonesia	Riau	Riau	Gallus gallus	NA
 EPI533369|A/chicken/Indonesia/PA/2003	A/chicken/Indonesia/PA/2003	avian_flu	EPI_ISL_163367	NA	Asia	Indonesia	NA	NA	Gallus gallus	NA
-EPI533370|A/chicken/Indonesia/BL/2003	A/chicken/Indonesia/BL/2003	avian_flu	EPI_ISL_163368	NA	Asia	Indonesia	Blitar	NA	Gallus gallus	NA
 EPI533371|A/chicken/Indonesia/2A/2003	A/chicken/Indonesia/2A/2003	avian_flu	EPI_ISL_163369	NA	Asia	Indonesia	Tangerang	NA	Gallus gallus	NA
 EPI533372|A/chicken/South Sulawesi/196/2011	A/chicken/South Sulawesi/196/2011	avian_flu	EPI_ISL_163370	NA	Asia	Indonesia	South Sulawesi	Makassar	Gallus gallus	NA
 EPI533373|A/chicken/South Sulawesi/195/2011	A/chicken/South Sulawesi/195/2011	avian_flu	EPI_ISL_163371	NA	Asia	Indonesia	South Sulawesi	Makassar	Gallus gallus	NA
@@ -24811,17 +24217,14 @@ EPI140799|A/Muscovy_duck/Vietnam/57/2007	A/Muscovy duck/Vietnam/57/2007	avian_fl
 EPI228599|A/duck/Chonburi/Thailand/CU-5/04	A/duck/Chonburi/Thailand/CU-5/04	avian_flu	EPI_ISL_65268	NA	Asia	Thailand	NA	NA	Duck	NA
 EPI228625|A/duck/Nakhon Pathom/Thailand/CU-71/04	A/duck/Nakhon Pathom/Thailand/CU-71/04	avian_flu	EPI_ISL_65294	NA	Asia	Thailand	NA	NA	Duck	NA
 EPI228627|A/duck/Saraburi/Thailand/CU-74/04	A/duck/Saraburi/Thailand/CU-74/04	avian_flu	EPI_ISL_65296	NA	Asia	Thailand	NA	NA	Duck	NA
-EPI644448|A/northern pintail/India/03OR320/2013	A/northern pintail/India/03OR320/2013	avian_flu	EPI_ISL_195970	2013-02-19	Asia	India	NA	NA	Anas acuta	NA
 EPI2200549|A/teal/Miyazaki/211109-32/2021	A/teal/Miyazaki/211109-32/2021	avian_flu	EPI_ISL_15613494	2021-11-09	Asia	Japan	Miyazaki	NA	Anas crecca	NA
 EPI228853|A/mallard/Guangxi/wt/2004	A/mallard/Guangxi/wt/2004	avian_flu	EPI_ISL_65324	NA	Asia	China	NA	NA	Anas platyrhynchos	NA
 EPI227293|A/Mallard/Huadong/S/2005	A/Mallard/Huadong/S/2005	avian_flu	EPI_ISL_64892	NA	Asia	China	NA	NA	Anas platyrhynchos	NA
 EPI227301|A/Mallard/Huadong/hn/2005	A/Mallard/Huadong/hn/2005	avian_flu	EPI_ISL_64893	NA	Asia	China	NA	NA	Anas platyrhynchos	NA
 EPI227309|A/Mallard/Huadong/lk/2005	A/Mallard/Huadong/lk/2005	avian_flu	EPI_ISL_64894	NA	Asia	China	NA	NA	Anas platyrhynchos	NA
 EPI1156382|A/mallard/France/150018/2015	A/mallard/France/150018/2015	avian_flu	EPI_ISL_294758	2015-02-19	Europe	France	NA	NA	Anas platyrhynchos	Wild
-NA	A/Anas platyrhynchos/Slovenia/359/2006	avian_flu	EPI_ISL_32507	NA	Europe	Slovenia	NA	NA	Anas platyrhynchos	NA
 EPI1954257|A/gadwall/Croatia/108/2021	A/gadwall/Croatia/108/2021	avian_flu	EPI_ISL_8568483	2021-11-22	Europe	Croatia	Splitsko-Dalmatinska Zupanija	Zaostrog, Podaca cove	Anas strepera	Wild
 EPI1847700|A/common buzzard/Netherlands/21021396-002/2021	A/common buzzard/Netherlands/21021396-002/2021	avian_flu	EPI_ISL_1048240	2021-01-09	Europe	Netherlands	Provincie Gelderland	Gemeente Zaltbommel	Buteo buteo	Wild
-NA	A/crow/India/02CA03/2012	avian_flu	EPI_ISL_195969	2012-02-19	Asia	India	NA	NA	Corvus	NA
 EPI644444|A/crow/India/01CA16/2012	A/crow/India/01CA16/2012	avian_flu	EPI_ISL_195968	2012-01-10	Asia	India	NA	NA	Corvus	NA
 EPI1841793|A/mallard/Netherlands/19001282-001/2019	A/mallard/Netherlands/19001282-001/2019	avian_flu	EPI_ISL_819124	2019-01-23	Europe	Netherlands	Provincie Noord-Holland	Gemeente Velsen	Mallard	Wild
 EPI2070078|1	A/mandarin duck/Heilongjiang/HL-1/2021	avian_flu	EPI_ISL_13352712	2021-10-03	Asia	China	Heilongjiang	NA	Aix galericulata	NA
@@ -24836,11 +24239,6 @@ EPI2070046|4.1	A/whooper swan/Shanxi/601/2021	avian_flu	EPI_ISL_13352703	2021-12
 EPI2070054|5.1	A/whooper swan/Shanxi/20/2021	avian_flu	EPI_ISL_13352704	2021-12-17	Asia	China	Shanxi	NA	Whooper swan	NA
 EPI2070062|6.1	A/whooper swan/Shanxi/14/2021	avian_flu	EPI_ISL_13352705	2021-12-17	Asia	China	Shanxi	NA	Whooper swan	NA
 EPI2070070|7.1	A/whooper swan/Henan/8/2021	avian_flu	EPI_ISL_13352706	2021-12-17	Asia	China	Henan	NA	Whooper swan	NA
-EPI2070094|3.1	A/whooper swan/Shanxi/608/2021	avian_flu	EPI_ISL_13352714	2021-12-17	Asia	China	Shanxi	NA	Whooper swan	NA
-EPI2070102|4.1	A/whooper swan/Shanxi/601/2021	avian_flu	EPI_ISL_13352715	2021-12-17	Asia	China	Shanxi	NA	Whooper swan	NA
-EPI2070110|5.1	A/whooper swan/Shanxi/20/2021	avian_flu	EPI_ISL_13352716	2021-12-17	Asia	China	Shanxi	NA	Whooper swan	NA
-EPI2070118|6.1	A/whooper swan/Shanxi/14/2021	avian_flu	EPI_ISL_13352717	2021-12-17	Asia	China	Shanxi	NA	Whooper swan	NA
-EPI2070126|7.1	A/whooper swan/Henan/8/2021	avian_flu	EPI_ISL_13352718	2021-12-17	Asia	China	Henan	NA	Whooper swan	NA
 EPI2070134|8.1	A/whooper swan/Henan/6/2021	avian_flu	EPI_ISL_13352719	2021-12-17	Asia	China	Henan	NA	Whooper swan	NA
 EPI2070142|9.1	A/whooper swan/Henan/44/2021	avian_flu	EPI_ISL_13352720	2021-12-17	Asia	China	Henan	NA	Whooper swan	NA
 EPI2070150|10.1	A/whooper swan/Henan/45/2021	avian_flu	EPI_ISL_13352721	2021-12-17	Asia	China	Henan	NA	Whooper swan	NA

--- a/scripts/clean_data_gisaid.R
+++ b/scripts/clean_data_gisaid.R
@@ -38,9 +38,9 @@ df_combined <- df_combined %>%
 # Reordena las columnas
 df_combined <- df_combined[,c(1,2,11,3,4,5,6,7,8,9,10)]
 
-# Elimina filas duplicadas en base a "isolate_id"
+# Elimina filas duplicadas en base a "strain"
 df_combined <- df_combined %>%
-  distinct(isolate_id, .keep_all = TRUE)
+  distinct(strain, .keep_all = TRUE)
 
 # Exporta el dataframe a un archivo TSV
 write_tsv(df_combined, "data/clean_metadata.tsv")


### PR DESCRIPTION
…nextstrain uses to identify a record.

This PR changes the `clean_data_gisaid.R` script to remove duplicate records based on the "strain" column, rather than the isolate_ID. It turns out that several Isolate_ID values share the same strain name. Strain name is what nextstrain uses to identify records.